### PR TITLE
fix: add cookie forwarding to student result download route

### DIFF
--- a/app/student/print-result/route.ts
+++ b/app/student/print-result/route.ts
@@ -95,6 +95,15 @@ export async function GET(request: NextRequest) {
       proxyHeaders.set("Authorization", `Bearer ${token}`);
     }
 
+    const cookieHeader = cookieStore
+      .getAll()
+      .map((cookie) => `${cookie.name}=${cookie.value}`)
+      .join("; ");
+
+    if (cookieHeader) {
+      proxyHeaders.set("Cookie", cookieHeader);
+    }
+
     const response = await fetch(backendUrl.toString(), {
       headers: proxyHeaders,
       credentials: "include",


### PR DESCRIPTION
- Forward all cookies from Next.js to backend API for proper student authentication
- Add Cookie header to proxy headers when fetching student results
- Ensures online result downloads work the same as offline downloads
- Fixes 403 "You do not have permission to download this result" error

# Pull Request Template

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue (Link to issue ticket)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
