### PR TITLE
feat(website): add Website Management MVP (branding, header, hero, publish)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,5 +23,7 @@ NEXT_PUBLIC_DEMO_MODE=off
 
 # Base URL of the public school-website app (school-public-web). Optional --
 # only used to build "view public website" links from Website Management.
-# Falls back to http://localhost:3000 if unset.
-NEXT_PUBLIC_PUBLIC_SITE_URL=http://localhost:3000
+# Falls back to http://localhost:3001 if unset. NOTE: 3001, not 3000 --
+# school-public-web pins its own dev port to 3001 specifically to avoid
+# colliding with this app (see its README for why).
+NEXT_PUBLIC_PUBLIC_SITE_URL=http://localhost:3001

--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,8 @@ NEXT_PUBLIC_EMAIL_VERIFICATION=off
 
 # Enable demo login shortcuts on the login page ("on" | "off")
 NEXT_PUBLIC_DEMO_MODE=off
+
+# Base URL of the public school-website app (school-public-web). Optional --
+# only used to build "view public website" links from Website Management.
+# Falls back to http://localhost:3000 if unset.
+NEXT_PUBLIC_PUBLIC_SITE_URL=http://localhost:3000

--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -1,0 +1,753 @@
+"use client";
+
+import Link from "next/link";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useAuth } from "@/contexts/AuthContext";
+import { ApiError } from "@/lib/apiClient";
+import { publicWebsiteUrl } from "@/lib/config";
+import {
+  createDefaultSchoolWebsite,
+  getSchoolWebsite,
+  saveSchoolWebsite,
+  type SchoolWebsite,
+  type SchoolWebsitePayload,
+  type SchoolWebsiteStatus,
+} from "@/lib/schoolWebsite";
+
+function toPayload(website: SchoolWebsite): SchoolWebsitePayload {
+  const { id, schoolId, publishedAt, createdAt, updatedAt, ...payload } =
+    website;
+  void id;
+  void schoolId;
+  void publishedAt;
+  void createdAt;
+  void updatedAt;
+  return payload;
+}
+
+const STATUS_LABELS: Record<SchoolWebsiteStatus | "unconfigured", string> = {
+  unconfigured: "Not configured",
+  draft: "Draft",
+  published: "Published",
+  unpublished: "Unpublished",
+};
+
+const STATUS_BADGE_CLASS: Record<SchoolWebsiteStatus | "unconfigured", string> = {
+  unconfigured: "badge badge-secondary",
+  draft: "badge badge-warning",
+  published: "badge badge-success",
+  unpublished: "badge badge-danger",
+};
+
+export default function WebsiteManagementPage() {
+  const { schoolContext, hasPermission } = useAuth();
+  const school = schoolContext.school;
+
+  const canView = hasPermission("settings.school.view");
+  const canManage = hasPermission("settings.school.update");
+
+  const [form, setForm] = useState<SchoolWebsitePayload | null>(null);
+  const [savedSnapshot, setSavedSnapshot] = useState<string | null>(null);
+  const [status, setStatus] = useState<SchoolWebsiteStatus | "unconfigured">(
+    "unconfigured",
+  );
+  const [publishedAt, setPublishedAt] = useState<string | null>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string[]> | null>(
+    null,
+  );
+  const [submittingStatus, setSubmittingStatus] =
+    useState<SchoolWebsiteStatus | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!school) {
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setLoadError(null);
+
+    getSchoolWebsite()
+      .then((website) => {
+        if (cancelled) {
+          return;
+        }
+
+        if (website) {
+          const payload = toPayload(website);
+          setForm(payload);
+          setSavedSnapshot(JSON.stringify(payload));
+          setStatus(website.status);
+          setPublishedAt(website.publishedAt);
+        } else {
+          const defaults = createDefaultSchoolWebsite(school);
+          setForm(defaults);
+          setSavedSnapshot(null);
+          setStatus("unconfigured");
+          setPublishedAt(null);
+        }
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+        console.error("Failed to load school website", error);
+        setLoadError(
+          error instanceof Error
+            ? error.message
+            : "Unable to load website settings. Please try again.",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [school]);
+
+  const hasUnsavedChanges = useMemo(() => {
+    if (!form) {
+      return false;
+    }
+    return JSON.stringify(form) !== savedSnapshot;
+  }, [form, savedSnapshot]);
+
+  const publicUrl = publicWebsiteUrl(school?.slug ?? null);
+
+  if (!canView) {
+    return (
+      <div className="row">
+        <div className="col-12">
+          <div className="card">
+            <div className="card-body">
+              <p className="mb-0">
+                You do not have permission to view Website Management.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (loading || !form) {
+    return (
+      <div className="row">
+        <div className="col-12">
+          <div className="card">
+            <div className="card-body">
+              {loadError ? (
+                <div className="alert alert-danger" role="alert">
+                  {loadError}
+                </div>
+              ) : (
+                <p className="mb-0">Loading website settings…</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const updateBranding = (key: "primaryColor" | "secondaryColor", value: string) => {
+    setForm((prev) =>
+      prev ? { ...prev, branding: { ...prev.branding, [key]: value } } : prev,
+    );
+  };
+
+  const updateHeader = (
+    key: "welcomeText" | "utilityText" | "tagline",
+    value: string,
+  ) => {
+    setForm((prev) =>
+      prev ? { ...prev, header: { ...prev.header, [key]: value } } : prev,
+    );
+  };
+
+  const updateHero = (
+    key: "eyebrow" | "title" | "description" | "imageUrl",
+    value: string,
+  ) => {
+    setForm((prev) =>
+      prev
+        ? {
+            ...prev,
+            hero: {
+              ...prev.hero,
+              [key]: key === "imageUrl" ? value || null : value,
+            },
+          }
+        : prev,
+    );
+  };
+
+  const updateHeroAction = (
+    which: "primaryAction" | "secondaryAction",
+    key: "label" | "href",
+    value: string,
+  ) => {
+    setForm((prev) =>
+      prev
+        ? {
+            ...prev,
+            hero: {
+              ...prev.hero,
+              [which]: { ...prev.hero[which], [key]: value },
+            },
+          }
+        : prev,
+    );
+  };
+
+  const updateInfoCard = (
+    key: "label" | "title" | "description",
+    value: string,
+  ) => {
+    setForm((prev) =>
+      prev
+        ? {
+            ...prev,
+            hero: {
+              ...prev.hero,
+              infoCard: { ...prev.hero.infoCard, [key]: value },
+            },
+          }
+        : prev,
+    );
+  };
+
+  const updateTrustItem = (index: number, value: string) => {
+    setForm((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      const items = [...prev.hero.trustItems];
+      items[index] = value;
+      return { ...prev, hero: { ...prev.hero, trustItems: items } };
+    });
+  };
+
+  const fieldError = (key: string): string | null => {
+    const messages = fieldErrors?.[key];
+    return messages && messages.length > 0 ? messages[0] : null;
+  };
+
+  const handleSave = async (nextStatus: SchoolWebsiteStatus) => {
+    if (!form) {
+      return;
+    }
+
+    setSubmittingStatus(nextStatus);
+    setSubmitError(null);
+    setFieldErrors(null);
+    setSuccessMessage(null);
+
+    const trustItems = form.hero.trustItems
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    if (trustItems.length === 0) {
+      setSubmitError(
+        "At least one trust item is required. Fill in at least one of the trust item fields.",
+      );
+      setSubmittingStatus(null);
+      return;
+    }
+
+    const heroTitle = form.hero.title.trim() || school?.name || "Our School";
+    const heroDescription = form.hero.description.trim();
+
+    const payload: SchoolWebsitePayload = {
+      ...form,
+      hero: { ...form.hero, title: heroTitle, trustItems },
+      seo: {
+        ...form.seo,
+        title: heroTitle,
+        description: heroDescription || form.seo.description,
+        imageUrl: form.hero.imageUrl,
+      },
+    };
+
+    try {
+      const saved = await saveSchoolWebsite(payload, nextStatus);
+      const savedPayload = toPayload(saved);
+      setForm(savedPayload);
+      setSavedSnapshot(JSON.stringify(savedPayload));
+      setStatus(saved.status);
+      setPublishedAt(saved.publishedAt);
+      setSuccessMessage(
+        nextStatus === "published"
+          ? "Website published."
+          : nextStatus === "unpublished"
+            ? "Website unpublished."
+            : "Draft saved.",
+      );
+    } catch (error) {
+      console.error("Failed to save school website", error);
+      if (error instanceof ApiError && error.status === 422 && error.errors) {
+        setFieldErrors(error.errors);
+        setSubmitError("Please fix the highlighted fields and try again.");
+      } else {
+        setSubmitError(
+          error instanceof Error
+            ? error.message
+            : "Unable to save website settings. Please try again.",
+        );
+      }
+    } finally {
+      setSubmittingStatus(null);
+    }
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    handleSave(status === "unconfigured" ? "draft" : status);
+  };
+
+  return (
+    <>
+      <div className="breadcrumbs-area">
+        <h3>Website Management</h3>
+        <ul>
+          <li>
+            <Link href="/v10/dashboard">Home</Link>
+          </li>
+          <li>Website Management</li>
+        </ul>
+      </div>
+
+      {loadError ? (
+        <div className="alert alert-danger" role="alert">
+          {loadError}
+        </div>
+      ) : null}
+      {submitError ? (
+        <div className="alert alert-danger" role="alert">
+          {submitError}
+        </div>
+      ) : null}
+      {successMessage ? (
+        <div className="alert alert-success" role="alert">
+          {successMessage}
+        </div>
+      ) : null}
+
+      <div className="row">
+        <div className="col-12">
+          <div className="card">
+            <div className="card-body">
+              <div className="heading-layout1">
+                <div className="item-title">
+                  <h3>
+                    Website Status:{" "}
+                    <span className={STATUS_BADGE_CLASS[status]}>
+                      {STATUS_LABELS[status]}
+                    </span>
+                  </h3>
+                  {publishedAt ? (
+                    <p className="mb-0">
+                      Last published {new Date(publishedAt).toLocaleString()}
+                    </p>
+                  ) : null}
+                </div>
+                {publicUrl ? (
+                  <a
+                    href={publicUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="btn-fill-lg bg-blue-dark btn-hover-yellow"
+                  >
+                    View Public Website
+                  </a>
+                ) : (
+                  <p className="mb-0 text-muted">
+                    Public website link unavailable (school has no slug yet).
+                  </p>
+                )}
+              </div>
+
+              <form
+                id="website-management-form"
+                className="new-added-form"
+                onSubmit={handleSubmit}
+              >
+                <h4 className="mt-4">Branding</h4>
+                <div className="row">
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="branding-primary-color">Primary Colour *</label>
+                    <div className="d-flex align-items-center">
+                      <input
+                        id="branding-primary-color"
+                        type="color"
+                        value={form.branding.primaryColor}
+                        onChange={(event) =>
+                          updateBranding("primaryColor", event.target.value)
+                        }
+                        style={{ width: 48, height: 38, marginRight: 8 }}
+                      />
+                      <input
+                        type="text"
+                        className="form-control"
+                        value={form.branding.primaryColor}
+                        onChange={(event) =>
+                          updateBranding("primaryColor", event.target.value)
+                        }
+                        placeholder="#172033"
+                        required
+                      />
+                    </div>
+                    {fieldError("branding.primaryColor") ? (
+                      <small className="text-danger">
+                        {fieldError("branding.primaryColor")}
+                      </small>
+                    ) : null}
+                  </div>
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="branding-secondary-color">
+                      Secondary Colour *
+                    </label>
+                    <div className="d-flex align-items-center">
+                      <input
+                        id="branding-secondary-color"
+                        type="color"
+                        value={form.branding.secondaryColor}
+                        onChange={(event) =>
+                          updateBranding("secondaryColor", event.target.value)
+                        }
+                        style={{ width: 48, height: 38, marginRight: 8 }}
+                      />
+                      <input
+                        type="text"
+                        className="form-control"
+                        value={form.branding.secondaryColor}
+                        onChange={(event) =>
+                          updateBranding("secondaryColor", event.target.value)
+                        }
+                        placeholder="#f97316"
+                        required
+                      />
+                    </div>
+                    {fieldError("branding.secondaryColor") ? (
+                      <small className="text-danger">
+                        {fieldError("branding.secondaryColor")}
+                      </small>
+                    ) : null}
+                  </div>
+                </div>
+
+                <h4 className="mt-4">Header</h4>
+                <div className="row">
+                  <div className="col-lg-4 col-12 form-group">
+                    <label htmlFor="header-welcome-text">Welcome Text *</label>
+                    <input
+                      id="header-welcome-text"
+                      type="text"
+                      className="form-control"
+                      value={form.header.welcomeText}
+                      onChange={(event) =>
+                        updateHeader("welcomeText", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-4 col-12 form-group">
+                    <label htmlFor="header-utility-text">Utility Text *</label>
+                    <input
+                      id="header-utility-text"
+                      type="text"
+                      className="form-control"
+                      value={form.header.utilityText}
+                      onChange={(event) =>
+                        updateHeader("utilityText", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-4 col-12 form-group">
+                    <label htmlFor="header-tagline">Tagline *</label>
+                    <input
+                      id="header-tagline"
+                      type="text"
+                      className="form-control"
+                      value={form.header.tagline}
+                      onChange={(event) =>
+                        updateHeader("tagline", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                </div>
+
+                <h4 className="mt-4">Hero</h4>
+                <div className="row">
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="hero-eyebrow">Eyebrow *</label>
+                    <input
+                      id="hero-eyebrow"
+                      type="text"
+                      className="form-control"
+                      value={form.hero.eyebrow}
+                      onChange={(event) =>
+                        updateHero("eyebrow", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="hero-title">Title *</label>
+                    <input
+                      id="hero-title"
+                      type="text"
+                      className="form-control"
+                      value={form.hero.title}
+                      onChange={(event) => updateHero("title", event.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="col-12 form-group">
+                    <label htmlFor="hero-description">Description *</label>
+                    <textarea
+                      id="hero-description"
+                      className="textarea form-control"
+                      rows={4}
+                      value={form.hero.description}
+                      onChange={(event) =>
+                        updateHero("description", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-12 form-group">
+                    <label htmlFor="hero-image-url">Hero Image URL</label>
+                    <input
+                      id="hero-image-url"
+                      type="url"
+                      className="form-control"
+                      value={form.hero.imageUrl ?? ""}
+                      onChange={(event) =>
+                        updateHero("imageUrl", event.target.value)
+                      }
+                      placeholder="https://example.com/hero.jpg"
+                    />
+                    <small className="form-text text-muted">
+                      Paste a publicly accessible image URL. Direct file uploads
+                      will be added later.
+                    </small>
+                  </div>
+
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="hero-primary-action-label">
+                      Primary Action Label *
+                    </label>
+                    <input
+                      id="hero-primary-action-label"
+                      type="text"
+                      className="form-control"
+                      value={form.hero.primaryAction.label}
+                      onChange={(event) =>
+                        updateHeroAction(
+                          "primaryAction",
+                          "label",
+                          event.target.value,
+                        )
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="hero-primary-action-href">
+                      Primary Action Link *
+                    </label>
+                    <input
+                      id="hero-primary-action-href"
+                      type="text"
+                      className="form-control"
+                      value={form.hero.primaryAction.href}
+                      onChange={(event) =>
+                        updateHeroAction(
+                          "primaryAction",
+                          "href",
+                          event.target.value,
+                        )
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="hero-secondary-action-label">
+                      Secondary Action Label *
+                    </label>
+                    <input
+                      id="hero-secondary-action-label"
+                      type="text"
+                      className="form-control"
+                      value={form.hero.secondaryAction.label}
+                      onChange={(event) =>
+                        updateHeroAction(
+                          "secondaryAction",
+                          "label",
+                          event.target.value,
+                        )
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="hero-secondary-action-href">
+                      Secondary Action Link *
+                    </label>
+                    <input
+                      id="hero-secondary-action-href"
+                      type="text"
+                      className="form-control"
+                      value={form.hero.secondaryAction.href}
+                      onChange={(event) =>
+                        updateHeroAction(
+                          "secondaryAction",
+                          "href",
+                          event.target.value,
+                        )
+                      }
+                      required
+                    />
+                  </div>
+
+                  <div className="col-12 form-group">
+                    <label>Trust Items *</label>
+                    <div className="row">
+                      {[0, 1, 2].map((index) => (
+                        <div className="col-lg-4 col-12" key={index}>
+                          <input
+                            type="text"
+                            className="form-control mb-2"
+                            value={form.hero.trustItems[index] ?? ""}
+                            onChange={(event) =>
+                              updateTrustItem(index, event.target.value)
+                            }
+                            placeholder={`Trust item ${index + 1}`}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <small className="form-text text-muted">
+                      At least one trust item is required. Empty items are
+                      ignored when saving.
+                    </small>
+                  </div>
+
+                  <div className="col-lg-4 col-12 form-group">
+                    <label htmlFor="hero-info-card-label">
+                      Info Card Label *
+                    </label>
+                    <input
+                      id="hero-info-card-label"
+                      type="text"
+                      className="form-control"
+                      value={form.hero.infoCard.label}
+                      onChange={(event) =>
+                        updateInfoCard("label", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-4 col-12 form-group">
+                    <label htmlFor="hero-info-card-title">
+                      Info Card Title *
+                    </label>
+                    <input
+                      id="hero-info-card-title"
+                      type="text"
+                      className="form-control"
+                      value={form.hero.infoCard.title}
+                      onChange={(event) =>
+                        updateInfoCard("title", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-4 col-12 form-group">
+                    <label htmlFor="hero-info-card-description">
+                      Info Card Description *
+                    </label>
+                    <input
+                      id="hero-info-card-description"
+                      type="text"
+                      className="form-control"
+                      value={form.hero.infoCard.description}
+                      onChange={(event) =>
+                        updateInfoCard("description", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                </div>
+
+                {!canManage ? (
+                  <p className="text-muted mt-3">
+                    You have read-only access to Website Management and cannot
+                    save changes.
+                  </p>
+                ) : (
+                  <div className="col-12 form-group mg-t-8">
+                    <button
+                      type="submit"
+                      className="btn-fill-lg btn-gradient-yellow btn-hover-bluedark"
+                      disabled={submittingStatus !== null}
+                    >
+                      {submittingStatus === "draft"
+                        ? "Saving…"
+                        : "Save as Draft"}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-fill-lg bg-blue-dark btn-hover-yellow"
+                      disabled={submittingStatus !== null}
+                      onClick={() => handleSave("published")}
+                    >
+                      {submittingStatus === "published"
+                        ? "Publishing…"
+                        : "Publish Website"}
+                    </button>
+                    {status === "published" ? (
+                      <button
+                        type="button"
+                        className="btn-fill-lg bg-dark-pastel-green btn-hover-yellow"
+                        disabled={submittingStatus !== null}
+                        onClick={() => handleSave("unpublished")}
+                      >
+                        {submittingStatus === "unpublished"
+                          ? "Unpublishing…"
+                          : "Unpublish Website"}
+                      </button>
+                    ) : null}
+                    {hasUnsavedChanges ? (
+                      <span className="text-warning ml-2">
+                        You have unsaved changes.
+                      </span>
+                    ) : null}
+                  </div>
+                )}
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+      <footer className="footer-wrap-layout1">
+        <div className="copyright">
+          © Copyrights <a href="#">Cyfamod Technologies</a> 2026. All rights
+          reserved.
+        </div>
+      </footer>
+    </>
+  );
+}

--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -5,6 +5,7 @@ import { FormEvent, useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { ApiError } from "@/lib/apiClient";
 import { publicWebsiteUrl } from "@/lib/config";
+import { userHasRole } from "@/lib/roleChecks";
 import {
   createDefaultSchoolWebsite,
   getSchoolWebsite,
@@ -40,11 +41,13 @@ const STATUS_BADGE_CLASS: Record<SchoolWebsiteStatus | "unconfigured", string> =
 };
 
 export default function WebsiteManagementPage() {
-  const { schoolContext, hasPermission } = useAuth();
+  const { user, schoolContext, hasPermission } = useAuth();
   const school = schoolContext.school;
 
-  const canView = hasPermission("settings.school.view");
-  const canManage = hasPermission("settings.school.update");
+  const isAdminUser =
+    userHasRole(user, "admin") || userHasRole(user, "super_admin");
+  const canView = isAdminUser && hasPermission("settings.school.view");
+  const canManage = isAdminUser && hasPermission("settings.school.update");
 
   const [form, setForm] = useState<SchoolWebsitePayload | null>(null);
   const [savedSnapshot, setSavedSnapshot] = useState<string | null>(null);

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -218,6 +218,11 @@ export function getMenuSections(enableSessionResultPrint = false): MenuSection[]
       icon: "flaticon-settings",
       links: [
         { label: "School Settings", href: "/v10/profile", requiredRoles: ["admin"] },
+        {
+          label: "Website Management",
+          href: "/v28/website-management",
+          requiredPermissions: "settings.school.view",
+        },
       ],
     },
   ];

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -221,6 +221,7 @@ export function getMenuSections(enableSessionResultPrint = false): MenuSection[]
         {
           label: "Website Management",
           href: "/v28/website-management",
+          requiredRoles: ["admin"],
           requiredPermissions: "settings.school.view",
         },
       ],

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -4,13 +4,43 @@ import { getCookie } from "@/lib/cookies";
 type FetchOptions = RequestInit & {
   skipAuth?: boolean;
   authScope?: "staff" | "student";
+  /**
+   * By default, a 403 on a read-only staff request returns `[]` instead of
+   * throwing, since most callers are list endpoints. Set to `false` for
+   * single-object endpoints where `[]` would be a type-unsafe, misleading
+   * stand-in for "forbidden" (see ApiError below for the correct signal).
+   */
+  treatForbiddenAsEmpty?: boolean;
 };
+
+export class ApiError extends Error {
+  readonly status: number;
+  /** Laravel's per-field validation errors on a 422 response, if present. */
+  readonly errors?: Record<string, string[]>;
+
+  constructor(
+    message: string,
+    status: number,
+    errors?: Record<string, string[]>,
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.errors = errors;
+  }
+}
 
 export async function apiFetch<T = unknown>(
   path: string,
   options: FetchOptions = {},
 ): Promise<T> {
-  const { skipAuth = false, authScope = "staff", headers, ...rest } = options;
+  const {
+    skipAuth = false,
+    authScope = "staff",
+    treatForbiddenAsEmpty = true,
+    headers,
+    ...rest
+  } = options;
   const tokenName = authScope === "student" ? "student_token" : "token";
   const token = getCookie(tokenName);
   const resolvedHeaders = new Headers(headers);
@@ -43,7 +73,10 @@ export async function apiFetch<T = unknown>(
         );
       }
 
-      throw new Error("Session expired. Re-checking authentication.");
+      throw new ApiError(
+        "Session expired. Re-checking authentication.",
+        response.status,
+      );
     }
 
     // For 403 (Forbidden) errors on read-only staff requests, return empty data
@@ -51,18 +84,31 @@ export async function apiFetch<T = unknown>(
     // the UI can surface proper error feedback.
     const method = (rest.method ?? "GET").toString().toUpperCase();
     const isReadOnlyMethod = method === "GET" || method === "HEAD";
-    if (response.status === 403 && authScope === "staff" && isReadOnlyMethod) {
+    if (
+      response.status === 403 &&
+      authScope === "staff" &&
+      isReadOnlyMethod &&
+      treatForbiddenAsEmpty
+    ) {
       return [] as T;
     }
-    
+
     let message = response.statusText;
+    let validationErrors: Record<string, string[]> | undefined;
     try {
       const data = await response.json();
       message = data.message ?? JSON.stringify(data);
+      if (data.errors && typeof data.errors === "object") {
+        validationErrors = data.errors;
+      }
     } catch {
       // ignore parse errors, fall back to status text
     }
-    throw new Error(message || `Request failed (${response.status})`);
+    throw new ApiError(
+      message || `Request failed (${response.status})`,
+      response.status,
+      validationErrors,
+    );
   }
 
   if (response.status === 204) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -54,6 +54,7 @@ export interface User {
 export interface School {
   id: number;
   name: string;
+  slug?: string | null;
   logo_url?: string | null;
   email?: string | null;
   phone?: string | null;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -39,6 +39,20 @@ function requireStorageUrl(): string {
 
 export const STORAGE_URL = requireStorageUrl();
 
+// Optional: base URL of the public school-website app (school-public-web),
+// used only to build "view public website" links. Not required for the
+// rest of the app to function, so it falls back rather than throwing.
+export const PUBLIC_SITE_URL = (
+  process.env.NEXT_PUBLIC_PUBLIC_SITE_URL || "http://localhost:3000"
+).replace(/\/$/, "");
+
+export function publicWebsiteUrl(schoolSlug: string | null | undefined): string | null {
+  if (!schoolSlug) {
+    return null;
+  }
+  return `${PUBLIC_SITE_URL}/schools/${encodeURIComponent(schoolSlug)}`;
+}
+
 const SCHOOL_REGISTRATION_FLAG = (
   process.env.NEXT_PUBLIC_SCHOOL_REGISTRATION ?? "off"
 )
@@ -102,6 +116,7 @@ export const API_ROUTES = {
   logoutOtherDevices: "/api/v1/logout/other-devices",
   currentUser: "/api/v1/user",
   schoolContext: "/api/v1/school",
+  schoolWebsite: "/api/v1/school/website",
   classes: "/api/v1/classes",
   parents: "/api/v1/parents",
   parentsSearch: "/api/v1/parents",

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -42,8 +42,14 @@ export const STORAGE_URL = requireStorageUrl();
 // Optional: base URL of the public school-website app (school-public-web),
 // used only to build "view public website" links. Not required for the
 // rest of the app to function, so it falls back rather than throwing.
+//
+// Defaults to port 3001, NOT 3000 -- school-public-web pins its dev/start
+// scripts to 3001 specifically to avoid colliding with this app (both
+// default to Next.js's port 3000 otherwise). If this default is ever
+// changed back to 3000, the "View Public Website" link will silently
+// point at this app instead of school-public-web.
 export const PUBLIC_SITE_URL = (
-  process.env.NEXT_PUBLIC_PUBLIC_SITE_URL || "http://localhost:3000"
+  process.env.NEXT_PUBLIC_PUBLIC_SITE_URL || "http://localhost:3001"
 ).replace(/\/$/, "");
 
 export function publicWebsiteUrl(schoolSlug: string | null | undefined): string | null {

--- a/lib/schoolWebsite.ts
+++ b/lib/schoolWebsite.ts
@@ -1,0 +1,304 @@
+import { ApiError, apiFetch } from "@/lib/apiClient";
+import type { School } from "@/lib/auth";
+import { API_ROUTES } from "@/lib/config";
+
+export type SchoolWebsiteStatus = "draft" | "published" | "unpublished";
+
+export interface WebsiteAction {
+  label: string;
+  href: string;
+}
+
+export interface WebsiteBranding {
+  primaryColor: string;
+  secondaryColor: string;
+}
+
+export interface WebsiteSeo {
+  title: string;
+  description: string;
+  imageUrl: string | null;
+}
+
+export interface WebsiteHeader {
+  welcomeText: string;
+  utilityText: string;
+  tagline: string;
+}
+
+export interface WebsiteHero {
+  eyebrow: string;
+  title: string;
+  description: string;
+  imageUrl: string | null;
+  primaryAction: WebsiteAction;
+  secondaryAction: WebsiteAction;
+  trustItems: string[];
+  infoCard: {
+    label: string;
+    title: string;
+    description: string;
+  };
+}
+
+export interface WebsiteHighlight {
+  id: string;
+  title: string;
+  description: string;
+  iconUrl: string | null;
+}
+
+export interface WebsiteAbout {
+  eyebrow: string;
+  title: string;
+  description: string;
+  imageUrl: string | null;
+  mission: string;
+  vision: string;
+}
+
+export interface WebsiteProgramme {
+  id: string;
+  name: string;
+  summary: string;
+  imageUrl: string | null;
+}
+
+export interface WebsiteAdmissions {
+  eyebrow: string;
+  title: string;
+  description: string;
+  action: WebsiteAction;
+}
+
+export interface WebsiteContact {
+  address: string;
+  phone: string;
+  email: string;
+  mapUrl: string | null;
+}
+
+export interface WebsiteSocialLinks {
+  facebook: string | null;
+  instagram: string | null;
+  linkedin: string | null;
+  youtube: string | null;
+  x: string | null;
+}
+
+export interface WebsiteEnabledSections {
+  hero: boolean;
+  highlights: boolean;
+  about: boolean;
+  programmes: boolean;
+  admissions: boolean;
+  contact: boolean;
+}
+
+/** The full website contract, as returned by GET /api/v1/school/website. */
+export interface SchoolWebsite {
+  id: string;
+  schoolId: string;
+  contractVersion: 1;
+  status: SchoolWebsiteStatus;
+  themeKey: string;
+  branding: WebsiteBranding;
+  seo: WebsiteSeo;
+  header: WebsiteHeader;
+  hero: WebsiteHero;
+  highlights: WebsiteHighlight[];
+  about: WebsiteAbout;
+  programmes: WebsiteProgramme[];
+  admissions: WebsiteAdmissions;
+  contact: WebsiteContact;
+  socialLinks: WebsiteSocialLinks;
+  enabledSections: WebsiteEnabledSections;
+  publishedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** The full contract minus server-managed fields, as sent to PUT. */
+export type SchoolWebsitePayload = Omit<
+  SchoolWebsite,
+  "id" | "schoolId" | "publishedAt" | "createdAt" | "updatedAt"
+>;
+
+type SchoolWebsiteResponse = SchoolWebsite | { data: SchoolWebsite };
+
+/**
+ * Laravel's default JsonResource wraps single-resource responses in a
+ * `{ data: ... }` envelope (confirmed against the live endpoint -- not
+ * disabled via withoutWrapping() anywhere in this backend). Same defensive
+ * unwrap already used by lib/school.ts and lib/resultPageSettings.ts for
+ * their own endpoints' envelopes.
+ */
+function unwrap(payload: SchoolWebsiteResponse): SchoolWebsite {
+  if (payload && typeof payload === "object" && "data" in payload) {
+    return (payload as { data: SchoolWebsite }).data;
+  }
+  return payload as SchoolWebsite;
+}
+
+export async function getSchoolWebsite(): Promise<SchoolWebsite | null> {
+  try {
+    const payload = await apiFetch<SchoolWebsiteResponse>(
+      API_ROUTES.schoolWebsite,
+      { treatForbiddenAsEmpty: false },
+    );
+    return unwrap(payload);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return null;
+    }
+
+    // 401 (session expired), 403 (no permission), 422, 500, and network
+    // failures all mean something real went wrong -- never mask them as
+    // "no website configured yet".
+    throw error;
+  }
+}
+
+const PLACEHOLDER_HIGHLIGHT: WebsiteHighlight = {
+  id: "highlight-1",
+  title: "Update this highlight",
+  description: "Edit or replace this from a future Highlights editor.",
+  iconUrl: null,
+};
+
+const PLACEHOLDER_PROGRAMME: WebsiteProgramme = {
+  id: "programme-1",
+  name: "Update this programme",
+  summary: "Edit or replace this from a future Programmes editor.",
+  imageUrl: null,
+};
+
+/**
+ * Backfills contract sections the MVP form can't edit but the backend's
+ * `required` validation still rejects when empty (confirmed live: an
+ * existing website loaded with `highlights: []`/`programmes: []` -- which
+ * can happen for records seeded before this validation existed, or any
+ * other bypass of the FormRequest -- 422s on save with "highlights field
+ * is required" otherwise). Always called before PUT so a save never fails
+ * because of a section this form doesn't touch.
+ */
+function ensureValidNonMvpSections(
+  payload: SchoolWebsitePayload,
+): SchoolWebsitePayload {
+  return {
+    ...payload,
+    highlights:
+      payload.highlights.length > 0 ? payload.highlights : [PLACEHOLDER_HIGHLIGHT],
+    programmes:
+      payload.programmes.length > 0 ? payload.programmes : [PLACEHOLDER_PROGRAMME],
+  };
+}
+
+export async function saveSchoolWebsite(
+  payload: SchoolWebsitePayload,
+  status: SchoolWebsiteStatus,
+): Promise<SchoolWebsite> {
+  const response = await apiFetch<SchoolWebsiteResponse>(
+    API_ROUTES.schoolWebsite,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        ...ensureValidNonMvpSections(payload),
+        status,
+      }),
+    },
+  );
+  return unwrap(response);
+}
+
+const THEME_KEY = "kidza-home-2";
+
+/**
+ * A complete, backend-valid payload for a school that has never configured
+ * a website. Only branding/header/hero/status are surfaced in the MVP form,
+ * but Laravel's `required` rule rejects empty strings AND empty arrays
+ * (confirmed against UpsertSchoolWebsiteRequest and the passing test
+ * suite's fixtures) -- so every non-MVP section still needs a real,
+ * non-empty value, including one seed entry each for `highlights` and
+ * `programmes`. `enabledSections` keeps them hidden from the public site
+ * until their own editors exist.
+ */
+export function createDefaultSchoolWebsite(school: School): SchoolWebsitePayload {
+  const name = school.name?.trim() || "Our School";
+  const address = school.address?.trim() || "Address not yet provided.";
+  const phone = school.phone ? `${school.phone}`.trim() : "";
+  const email = school.email?.trim() || "";
+
+  return {
+    contractVersion: 1,
+    status: "draft",
+    themeKey: THEME_KEY,
+    branding: {
+      primaryColor: "#172033",
+      secondaryColor: "#f97316",
+    },
+    seo: {
+      title: name,
+      description: `Welcome to ${name}.`,
+      imageUrl: school.logo_url ?? null,
+    },
+    header: {
+      welcomeText: "Welcome to",
+      utilityText: "Admissions are open",
+      tagline: "Learning without limits",
+    },
+    hero: {
+      eyebrow: "Now enrolling",
+      title: name,
+      description: `A place where every learner at ${name} thrives.`,
+      imageUrl: school.logo_url ?? null,
+      primaryAction: { label: "Apply now", href: "/apply" },
+      secondaryAction: { label: "Learn more", href: "/about" },
+      trustItems: ["Quality education"],
+      infoCard: {
+        label: "Welcome",
+        title: name,
+        description: "Update this card from Website Management.",
+      },
+    },
+    // Not editable in this MVP -- kept valid-but-hidden via enabledSections
+    // until their own editors ship.
+    highlights: [PLACEHOLDER_HIGHLIGHT],
+    about: {
+      eyebrow: "About us",
+      title: "Our story",
+      description: `${name} is committed to providing a supportive, high-quality learning environment.`,
+      imageUrl: null,
+      mission: "Update this mission statement from Website Management.",
+      vision: "Update this vision statement from Website Management.",
+    },
+    programmes: [PLACEHOLDER_PROGRAMME],
+    admissions: {
+      eyebrow: "Admissions",
+      title: "Join us",
+      description: "Update the admissions description from Website Management.",
+      action: { label: "Apply", href: "/apply" },
+    },
+    contact: {
+      address,
+      phone: phone || "Not yet provided",
+      email: email || "info@example.com",
+      mapUrl: null,
+    },
+    socialLinks: {
+      facebook: null,
+      instagram: null,
+      linkedin: null,
+      youtube: null,
+      x: null,
+    },
+    enabledSections: {
+      hero: true,
+      highlights: false,
+      about: false,
+      programmes: false,
+      admissions: false,
+      contact: false,
+    },
+  };
+}


### PR DESCRIPTION
# Pull Request Template

## Description

Adds the **Website Management MVP** — a page under School Settings where an authenticated school administrator can view and edit their school's public website configuration (branding colours, header text, hero section) and control its publication state (draft / published / unpublished). This is the last piece connecting the four repos that make up the school-website feature:

```
This branch (school-fe-nextjs)
        ↓ PUT/GET
Authenticated Laravel API (school-be-laravel)          ✅ already merged
        ↓
school_websites table                                   ✅ already merged
        ↓
Public Laravel API (/api/v1/public/schools/{slug}/website) ✅ already merged
        ↓
school-public-web (renders the live site)                ✅ already merged
```

Once this merges, a school admin can go: open Website Management → edit hero/branding → Publish → open the public site link → see their change live. That loop didn't exist before this PR; every other piece did.

### What's in scope (MVP) vs. deferred

**Included:** branding, header, hero editing; draft/publish/unpublish; Laravel validation error display; public-site preview link.

**Explicitly deferred** (contract already supports them, no editor exists yet): highlights, about, programmes, admissions, contact, social links, image *uploads* (URL text input only for now).

## Related Issue (Link to issue ticket)

SWT-013 — add Linear link here. Depends on `Cyfamod-Technologies/school-be-laravel#94` (small permission-enforcement fix, separate PR, same author) — not a hard blocker since that PR is currently a no-op (`ENFORCE_ENDPOINT_PERMISSIONS` is off), but worth merging around the same time for consistency.

## Motivation and Context

The backend (`school-be-laravel`) and the public site (`school-public-web`) were both already wired up and working — a school's published website renders correctly at `/schools/{slug}`. But there was no way for a school admin to *create or edit* that content except by hand-writing JSON via `tinker` or `curl`, which is obviously not viable for real schools. This PR is the missing link: a real UI on top of the already-working `GET`/`PUT /api/v1/school/website` endpoints.

## How Has This Been Tested?

This was tested against the **real, running local backend** with real API calls, not just build/lint/typecheck — and that testing caught two real bugs before they reached the browser:

1. **Response envelope mismatch.** Laravel's default `JsonResource` wraps single-resource responses in `{ "data": {...} }`. I initially wrote `getSchoolWebsite()`/`saveSchoolWebsite()` assuming a flat object (matching the *public* endpoint's shape, which isn't wrapped). Confirmed the real, wrapped shape with a live `curl` call using a real bearer token, then fixed the client to unwrap it — the same defensive pattern already used in `lib/school.ts` and `lib/resultPageSettings.ts` for their own endpoints.
2. **Empty-array 422.** Laravel's `required` validation rule rejects empty arrays, not just missing/null values (confirmed by reading `UpsertSchoolWebsiteRequest` and cross-checking the passing backend test suite's fixtures, which always populate at least one `highlights`/`programmes` entry). Our own local seed data had `highlights: []`/`programmes: []` (created via `tinker`, bypassing validation) — so saving *any* existing website with that shape would 422. Fixed with `ensureValidNonMvpSections()`, which backfills a placeholder entry before every `PUT`, tested live against the real 422 response and then the real success response.

Concretely tested, end to end, against a live local Laravel instance:
- Logged in as a real seeded school admin (`POST /api/v1/login`)
- `GET /api/v1/school/website` → confirmed real response shape, unwrap logic
- `PUT /api/v1/school/website` with a full payload → confirmed `200`, confirmed the change persisted, confirmed the empty-array 422 case *and* its fix
- `pnpm lint`, `pnpm typecheck` (via `tsc --noEmit`, no dedicated script in this repo), `pnpm build` — all clean, scoped specifically to the files this PR touches (this repo has ~100 pre-existing lint issues in unrelated files; none of them are in this diff)

Not yet done: a full manual pass in an actual browser (the smoke test above was API-level via `curl`, simulating exactly what the page's fetch calls send/receive) — worth a quick click-through before merge, especially the colour pickers and the trust-items UI.

## Screenshots (if appropriate)

Not attached — recommend a screenshot of the page (empty state and populated state) before merge.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. — added `NEXT_PUBLIC_PUBLIC_SITE_URL` to `.env.example` with an explanation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. — no test framework is set up for this repo's frontend; verification was live/manual API testing (see above).
- [x] All new and existing tests passed. — `pnpm lint`/`typecheck`/`build` all clean for the changed files.

## Notes for the reviewer

- `lib/apiClient.ts` changes are additive and backward-compatible: `ApiError` extends `Error`, existing callers that just read `error.message` are unaffected; `treatForbiddenAsEmpty` defaults to `true` so all ~30 other callers keep their current behavior.
- The next free `app/(app)/vNN` folder was `v28` — confirmed by listing existing folders, not guessed.
- `app/(portal)/(app)/` is a stale, unmaintained duplicate of `app/(app)/` (confirmed via `git log` — zero commits ever touched it, and it's missing routes added since). This PR only adds to the live `app/(app)/` tree.
