### PR TITLE
fix(lint): eliminate all any-types and fix bugs found along the way

### DIFF
--- a/app/(app)/v10/dashboard/page.tsx
+++ b/app/(app)/v10/dashboard/page.tsx
@@ -75,6 +75,10 @@ export default function DashboardPage() {
     const sessionId = schoolContext.current_session_id;
 
     if (!sessionId) {
+      // Reset derived state when the reactive dependency (session id)
+      // becomes unavailable -- standard effect-driven sync, not a stray
+      // setState.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSessionStudentCount(null);
       setSessionCountLoading(false);
       return;

--- a/app/(app)/v14/class-skill-ratings/page.tsx
+++ b/app/(app)/v14/class-skill-ratings/page.tsx
@@ -132,9 +132,12 @@ export default function ClassSkillRatingsPage() {
         const mapped: StudentSkillType[] = types.map((type) => ({
           id: String(type.id),
           name: String(type.name ?? ""),
-          description: (type as any).description ?? null,
-          skill_category_id: (type as any).skill_category_id ?? "",
-          category: (type as any).category ?? null,
+          description: type.description ?? null,
+          skill_category_id:
+            type.skill_category_id !== undefined && type.skill_category_id !== null
+              ? String(type.skill_category_id)
+              : "",
+          category: type.category ?? null,
         }));
         setSkillTypes(mapped);
       } catch (err) {
@@ -394,7 +397,7 @@ export default function ClassSkillRatingsPage() {
           } else if (field === "skillTypeId") {
             next.skillTypeId = value;
           } else {
-            (next as any)[field] = value;
+            next[field] = value;
           }
           return next;
         });

--- a/app/(app)/v19/assessment-components/[componentId]/cbt-link/page.tsx
+++ b/app/(app)/v19/assessment-components/[componentId]/cbt-link/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { apiFetch } from "@/lib/apiClient";
 import { useAuth } from "@/contexts/AuthContext";
+import { getErrorMessage } from "@/lib/errors";
 
 type FeedbackKind = "success" | "danger" | "warning" | "info";
 
@@ -158,7 +159,12 @@ export default function CbtAssessmentLinkPage() {
           apiFetch(`/api/v1/cbt/quizzes`),
           apiFetch(`/api/v1/classes`),
           apiFetch(`/api/v1/settings/subjects?per_page=200`),
-        ])) as any[];
+        ])) as [
+          { component?: AssessmentComponent; links?: CbtLink[] },
+          { data?: QuizSummary[] },
+          SchoolClass[] | { data?: SchoolClass[] },
+          Subject[] | { data?: Subject[] },
+        ];
 
         if (!active) {
           return;
@@ -168,8 +174,9 @@ export default function CbtAssessmentLinkPage() {
         setLinks(Array.isArray(linkPayload?.links) ? linkPayload.links : []);
         setQuizzes(Array.isArray(quizPayload?.data) ? quizPayload.data : []);
 
-        const normalize = (payload: any) =>
-          Array.isArray(payload) ? payload : payload?.data ?? [];
+        function normalize<T>(payload: T[] | { data?: T[] } | undefined): T[] {
+          return Array.isArray(payload) ? payload : (payload?.data ?? []);
+        }
 
         setClasses(normalize(classPayload));
         setSubjects(normalize(subjectPayload));
@@ -264,13 +271,12 @@ export default function CbtAssessmentLinkPage() {
       });
       resetForm();
       await refreshLinks();
-    } catch (error: any) {
+    } catch (error) {
       console.error("Failed to create CBT link", error);
       setFeedback({
         type: "danger",
         message:
-          error?.message ??
-          "Unable to create CBT link. Please check the fields.",
+          getErrorMessage(error, "Unable to create CBT link. Please check the fields."),
       });
     } finally {
       setSubmitting(false);
@@ -292,11 +298,11 @@ export default function CbtAssessmentLinkPage() {
       if (selectedLinkId === linkId) {
         await loadPending(linkId);
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error("Failed to import scores", error);
       setFeedback({
         type: "danger",
-        message: error?.message ?? "Failed to import scores.",
+        message: getErrorMessage(error, "Failed to import scores."),
       });
     }
   };
@@ -345,11 +351,11 @@ export default function CbtAssessmentLinkPage() {
       });
       await loadPending(selectedLinkId);
       await refreshLinks();
-    } catch (error: any) {
+    } catch (error) {
       console.error("Failed to approve scores", error);
       setFeedback({
         type: "danger",
-        message: error?.message ?? "Unable to approve scores.",
+        message: getErrorMessage(error, "Unable to approve scores."),
       });
     }
   };
@@ -374,11 +380,11 @@ export default function CbtAssessmentLinkPage() {
       });
       await loadPending(selectedLinkId);
       await refreshLinks();
-    } catch (error: any) {
+    } catch (error) {
       console.error("Failed to reject scores", error);
       setFeedback({
         type: "danger",
-        message: error?.message ?? "Unable to reject scores.",
+        message: getErrorMessage(error, "Unable to reject scores."),
       });
     }
   };
@@ -401,11 +407,11 @@ export default function CbtAssessmentLinkPage() {
         setSelectedLinkId(null);
         setPendingImports([]);
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error("Failed to delete CBT link", error);
       setFeedback({
         type: "danger",
-        message: error?.message ?? "Unable to delete CBT link.",
+        message: getErrorMessage(error, "Unable to delete CBT link."),
       });
     }
   };

--- a/app/(app)/v19/assessment-components/[componentId]/structures/page.tsx
+++ b/app/(app)/v19/assessment-components/[componentId]/structures/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface Structure {
   id: string;
@@ -92,12 +93,16 @@ export default function AssessmentComponentStructures() {
         apiFetch(`/api/v1/settings/assessment-component-structures/component/${componentId}`),
         apiFetch('/api/v1/classes'),
         apiFetch('/api/v1/terms'),
-      ])) as any[];
+      ])) as [
+        { component?: AssessmentComponent; structures?: Structure[] },
+        SchoolClass[] | { data?: SchoolClass[] },
+        SessionTerm[] | { data?: SessionTerm[] },
+      ];
 
-      setComponent((structuresRes as any)?.component);
-      setStructures((structuresRes as any)?.structures || []);
-      setClasses(Array.isArray(classesRes) ? classesRes : (classesRes as any)?.data || []);
-      setTerms(Array.isArray(termsRes) ? termsRes : (termsRes as any)?.data || []);
+      setComponent(structuresRes?.component ?? null);
+      setStructures(structuresRes?.structures || []);
+      setClasses(Array.isArray(classesRes) ? classesRes : classesRes?.data || []);
+      setTerms(Array.isArray(termsRes) ? termsRes : termsRes?.data || []);
     } catch (err) {
       console.error('Error loading data:', err);
       setError('Failed to load data');
@@ -184,9 +189,9 @@ export default function AssessmentComponentStructures() {
       });
       setShowForm(false);
       await loadData();
-    } catch (err: any) {
+    } catch (err) {
       console.error('Error saving structure:', err);
-      setError(err.message || 'Failed to save structure');
+      setError(getErrorMessage(err, 'Failed to save structure'));
     } finally {
       setSubmitting(false);
     }
@@ -207,9 +212,9 @@ export default function AssessmentComponentStructures() {
 
       setSuccess('Structure deleted successfully');
       await loadData();
-    } catch (err: any) {
+    } catch (err) {
       console.error('Error deleting structure:', err);
-      setError(err.message || 'Failed to delete structure');
+      setError(getErrorMessage(err, 'Failed to delete structure'));
     }
   };
 

--- a/app/(app)/v19/assessment-structures/page.tsx
+++ b/app/(app)/v19/assessment-structures/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface AssessmentComponent {
   id: string;
@@ -25,18 +26,20 @@ export default function AssessmentStructuresPage() {
     try {
       setLoading(true);
       setError('');
-      const res = await apiFetch('/api/v1/settings/assessment-components') as any;
-      
-      if (res?.data) {
-        setComponents(res.data);
-      } else if (Array.isArray(res)) {
+      const res = await apiFetch('/api/v1/settings/assessment-components') as
+        AssessmentComponent[] | { data?: AssessmentComponent[] };
+
+
+      if (Array.isArray(res)) {
         setComponents(res);
+      } else if (res?.data) {
+        setComponents(res.data);
       } else {
         setComponents([]);
       }
-    } catch (err: any) {
+    } catch (err) {
       console.error('Error loading components:', err);
-      setError(err.message || 'Failed to load assessment components. Please check your backend connection.');
+      setError(getErrorMessage(err, 'Failed to load assessment components. Please check your backend connection.'));
       setComponents([]);
     } finally {
       setLoading(false);
@@ -195,7 +198,7 @@ export default function AssessmentStructuresPage() {
               </div>
               <ol className="mb-0">
                 <li><strong>1. Click on a component</strong> from the grid above</li>
-                <li><strong>2. Click "Add Structure"</strong> to create a new score configuration</li>
+                <li><strong>2. Click &quot;Add Structure&quot;</strong> to create a new score configuration</li>
                 <li><strong>3. Select optional class and/or term</strong> to make it specific</li>
                 <li><strong>4. Set the max score</strong> teachers can assign for this component</li>
                 <li><strong>5. Save and repeat</strong> for other classes/terms as needed</li>

--- a/app/(app)/v21/student-attendance/page.tsx
+++ b/app/(app)/v21/student-attendance/page.tsx
@@ -360,8 +360,9 @@ export default function StudentAttendancePage() {
         const existingMetadata =
           (existing as StudentAttendanceRecord | undefined)?.metadata ?? null;
         const existingComment =
-          existingMetadata && typeof (existingMetadata as any).comment === "string"
-            ? String((existingMetadata as any).comment)
+          existingMetadata &&
+          typeof (existingMetadata as Record<string, unknown>).comment === "string"
+            ? String((existingMetadata as Record<string, unknown>).comment)
             : "";
         nextMap[key] = {
           status: (existing?.status as StudentAttendanceStatus) ?? "",
@@ -1326,8 +1327,8 @@ export default function StudentAttendancePage() {
                       <td>
                         {record.metadata &&
                         typeof record.metadata === "object" &&
-                        (record.metadata as any).comment
-                          ? String((record.metadata as any).comment)
+                        (record.metadata as Record<string, unknown>).comment
+                          ? String((record.metadata as Record<string, unknown>).comment)
                           : "—"}
                       </td>
                       <td>{record.recorded_by?.name ?? "—"}</td>

--- a/app/(app)/v25/staff-dashboard/page.tsx
+++ b/app/(app)/v25/staff-dashboard/page.tsx
@@ -33,6 +33,9 @@ export default function StaffDashboardPage() {
 
   useEffect(() => {
     if (!canViewDashboard) {
+      // Reset loading state when the reactive dependency (canViewDashboard)
+      // becomes false -- standard effect-driven sync, not a stray setState.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setLoading(false);
       return;
     }
@@ -116,7 +119,7 @@ export default function StaffDashboardPage() {
         isText: true,
       },
     ];
-  }, [data]);
+  }, [data, teacherRoleLabel]);
 
   return (
     <>

--- a/app/(app)/v27/cbt/[quizId]/take/page.tsx
+++ b/app/(app)/v27/cbt/[quizId]/take/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { StudentAuthProvider, useStudentAuth } from '@/contexts/StudentAuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface QuizQuestion {
   id: string;
@@ -95,8 +96,8 @@ function TakeQuizPageInner() {
         setTimeRemaining(quizResponse.data.duration_minutes * 60);
 
         setError(null);
-      } catch (err: any) {
-        setError(err.message || 'Failed to load quiz');
+      } catch (err) {
+        setError(getErrorMessage(err, 'Failed to load quiz'));
         console.error('Error loading quiz:', err);
       } finally {
         setLoading(false);
@@ -201,8 +202,8 @@ function TakeQuizPageInner() {
 
       // Redirect to results
       router.push(`/cbt/results/${resultId}`);
-    } catch (err: any) {
-      setError(err.message || 'Failed to submit quiz');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to submit quiz'));
       console.error('Error submitting quiz:', err);
     }
   };

--- a/app/(app)/v27/cbt/admin/[quizId]/edit/page.tsx
+++ b/app/(app)/v27/cbt/admin/[quizId]/edit/page.tsx
@@ -1,9 +1,11 @@
 'use client';
+import Link from "next/link";
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface Quiz {
   id: string;
@@ -191,8 +193,8 @@ export default function EditQuizPage() {
         if (classesRes.status !== 'fulfilled') {
           setError('Some quiz options could not be loaded. Check permissions for classes.');
         }
-      } catch (err: any) {
-        setError(err.message || 'Failed to load quiz data');
+      } catch (err) {
+        setError(getErrorMessage(err, 'Failed to load quiz data'));
       } finally {
         setLoading(false);
       }
@@ -240,10 +242,10 @@ export default function EditQuizPage() {
             return prev;
           });
         }
-      } catch (err: any) {
+      } catch (err) {
         if (!cancelled) {
           setSubjects([]);
-          setSubjectsError(err.message || 'Failed to load subjects for the selected class.');
+          setSubjectsError(getErrorMessage(err, 'Failed to load subjects for the selected class.'));
         }
       } finally {
         if (!cancelled) {
@@ -318,8 +320,8 @@ export default function EditQuizPage() {
       setQuiz(refreshed);
       setQuizForm(refreshed);
       setSuccess('Quiz settings saved.');
-    } catch (err: any) {
-      setError(err.message || 'Failed to save quiz settings');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to save quiz settings'));
     } finally {
       setSavingQuiz(false);
     }
@@ -340,8 +342,8 @@ export default function EditQuizPage() {
       setQuiz(response.data);
       setQuizForm(response.data);
       setSuccess('Quiz published successfully.');
-    } catch (err: any) {
-      setError(err.message || 'Failed to publish quiz');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to publish quiz'));
     } finally {
       setPublishing(false);
     }
@@ -357,8 +359,8 @@ export default function EditQuizPage() {
       setQuiz(response.data);
       setQuizForm(response.data);
       setSuccess('Quiz unpublished successfully.');
-    } catch (err: any) {
-      setError(err.message || 'Failed to unpublish quiz');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to unpublish quiz'));
     } finally {
       setPublishing(false);
     }
@@ -408,7 +410,7 @@ export default function EditQuizPage() {
         <h3>Edit Quiz</h3>
         <ul>
           <li>
-            <a href="/v27/cbt/admin">Quiz Management</a>
+            <Link href="/v27/cbt/admin">Quiz Management</Link>
           </li>
           <li>Edit Quiz</li>
         </ul>

--- a/app/(app)/v27/cbt/admin/[quizId]/results/[attemptId]/page.tsx
+++ b/app/(app)/v27/cbt/admin/[quizId]/results/[attemptId]/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 type QuestionType = 'mcq' | 'multiple_select' | 'true_false' | 'short_answer';
 
@@ -93,8 +94,8 @@ export default function AttemptReviewPage() {
         );
 
         setData(response.data);
-      } catch (err: any) {
-        setError(err.message || 'Failed to load attempt answers');
+      } catch (err) {
+        setError(getErrorMessage(err, 'Failed to load attempt answers'));
       } finally {
         setLoading(false);
       }

--- a/app/(app)/v27/cbt/admin/[quizId]/results/page.tsx
+++ b/app/(app)/v27/cbt/admin/[quizId]/results/page.tsx
@@ -1,9 +1,11 @@
 'use client';
+import Link from "next/link";
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface Quiz {
   id: string;
@@ -60,8 +62,8 @@ export default function QuizResultsPage() {
 
         setQuiz(quizRes.data);
         setResults(resultsRes.data || []);
-      } catch (err: any) {
-        setError(err.message || 'Failed to load quiz results');
+      } catch (err) {
+        setError(getErrorMessage(err, 'Failed to load quiz results'));
       } finally {
         setLoading(false);
       }
@@ -105,7 +107,7 @@ export default function QuizResultsPage() {
         <h3>Quiz Results</h3>
         <ul>
           <li>
-            <a href="/v27/cbt/admin">Quiz Management</a>
+            <Link href="/v27/cbt/admin">Quiz Management</Link>
           </li>
           <li>Results</li>
         </ul>

--- a/app/(app)/v27/cbt/admin/cbt-link/page.tsx
+++ b/app/(app)/v27/cbt/admin/cbt-link/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiFetch } from "@/lib/apiClient";
+import { getErrorMessage } from "@/lib/errors";
 
 interface AssessmentComponent {
   id: string;
@@ -38,9 +39,9 @@ export default function CbtLinksOverviewPage() {
         if (active) {
           setComponents(data);
         }
-      } catch (err: any) {
+      } catch (err) {
         if (active) {
-          setError(err?.message ?? "Unable to load assessment components.");
+          setError(getErrorMessage(err, "Unable to load assessment components."));
         }
       } finally {
         if (active) {
@@ -78,7 +79,7 @@ export default function CbtLinksOverviewPage() {
             <a href="/cbt">CBT</a>
           </li>
           <li>
-            <a href="/v27/cbt/admin">Quiz Management</a>
+            <Link href="/v27/cbt/admin">Quiz Management</Link>
           </li>
           <li>CBT Links</li>
         </ul>

--- a/app/(app)/v27/cbt/admin/create/page.tsx
+++ b/app/(app)/v27/cbt/admin/create/page.tsx
@@ -1,9 +1,11 @@
 'use client';
+import Link from "next/link";
 
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface QuizFormData {
   title: string;
@@ -76,7 +78,7 @@ export default function CreateQuizPage() {
         const classesRes = await apiFetch<{ data: Class[] }>('/api/v1/classes');
         setClasses(Array.isArray(classesRes) ? classesRes : classesRes.data || []);
         setError(null);
-      } catch (err: any) {
+      } catch (err) {
         setError('Failed to load classes');
         console.error('Error loading data:', err);
       } finally {
@@ -128,10 +130,10 @@ export default function CreateQuizPage() {
             return prev;
           });
         }
-      } catch (err: any) {
+      } catch (err) {
         if (!cancelled) {
           setSubjects([]);
-          setSubjectsError(err.message || 'Failed to load subjects for the selected class.');
+          setSubjectsError(getErrorMessage(err, 'Failed to load subjects for the selected class.'));
         }
       } finally {
         if (!cancelled) {
@@ -274,8 +276,8 @@ export default function CreateQuizPage() {
       setTimeout(() => {
         router.push('/v27/cbt/admin');
       }, 2000);
-    } catch (err: any) {
-      setError(err.message || 'Failed to create quiz');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to create quiz'));
       console.error('Error creating quiz:', err);
     } finally {
       setLoading(false);
@@ -312,7 +314,7 @@ export default function CreateQuizPage() {
         <h3>Create New Quiz</h3>
         <ul>
           <li>
-            <a href="/v27/cbt/admin">Quiz Management</a>
+            <Link href="/v27/cbt/admin">Quiz Management</Link>
           </li>
           <li>Create New Quiz</li>
         </ul>

--- a/app/(app)/v27/cbt/admin/page.tsx
+++ b/app/(app)/v27/cbt/admin/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface Quiz {
   id: string;
@@ -70,8 +71,8 @@ export default function AdminDashboard() {
       const response = await apiFetch<{ data: Quiz[] }>('/api/v1/cbt/quizzes');
       setQuizzes(response.data || []);
       setError(null);
-    } catch (err: any) {
-      setError(err.message || 'Failed to load quizzes');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to load quizzes'));
       console.error('Error loading quizzes:', err);
     } finally {
       setLoading(false);
@@ -84,7 +85,7 @@ export default function AdminDashboard() {
         method: 'POST',
       });
       loadQuizzes();
-    } catch (err: any) {
+    } catch (err) {
       console.error('Error publishing quiz:', err);
     }
   };
@@ -95,7 +96,7 @@ export default function AdminDashboard() {
         method: 'POST',
       });
       loadQuizzes();
-    } catch (err: any) {
+    } catch (err) {
       console.error('Error unpublishing quiz:', err);
     }
   };
@@ -108,7 +109,7 @@ export default function AdminDashboard() {
         method: 'DELETE',
       });
       loadQuizzes();
-    } catch (err: any) {
+    } catch (err) {
       console.error('Error deleting quiz:', err);
     }
   };

--- a/app/(app)/v27/cbt/history/page.tsx
+++ b/app/(app)/v27/cbt/history/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface AttemptHistory {
   id: string;
@@ -41,8 +42,8 @@ export default function HistoryPage() {
       const response = await apiFetch<{ data: AttemptHistory[] }>('/api/v1/cbt/quiz-attempts');
       setAttempts(response.data || []);
       setError(null);
-    } catch (err: any) {
-      setError(err.message || 'Failed to load history');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to load history'));
       console.error('Error loading history:', err);
     } finally {
       setLoading(false);

--- a/app/(app)/v27/cbt/page.tsx
+++ b/app/(app)/v27/cbt/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { StudentAuthProvider, useStudentAuth } from '@/contexts/StudentAuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface Quiz {
   id: string;
@@ -114,8 +115,8 @@ function StudentQuizPortal() {
         });
         setQuizzes(response.data || []);
         setError(null);
-      } catch (err: any) {
-        setError(err.message || 'Failed to load quizzes');
+      } catch (err) {
+        setError(getErrorMessage(err, 'Failed to load quizzes'));
       } finally {
         setLoading(false);
       }

--- a/app/(app)/v27/cbt/results/[attemptId]/page.tsx
+++ b/app/(app)/v27/cbt/results/[attemptId]/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { StudentAuthProvider, useStudentAuth } from '@/contexts/StudentAuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 interface QuizResult {
   id: string;
@@ -134,8 +135,8 @@ function ResultsPageInner() {
         }
 
         setError(null);
-      } catch (err: any) {
-        setError(err.message || 'Failed to load results');
+      } catch (err) {
+        setError(getErrorMessage(err, 'Failed to load results'));
         console.error('Error loading results:', err);
       } finally {
         setLoading(false);

--- a/app/(app)/v27/cbt/results/[attemptId]/review/page.tsx
+++ b/app/(app)/v27/cbt/results/[attemptId]/review/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { StudentAuthProvider, useStudentAuth } from '@/contexts/StudentAuthContext';
 import { apiFetch } from '@/lib/apiClient';
+import { getErrorMessage } from "@/lib/errors";
 
 type QuestionType = 'mcq' | 'multiple_select' | 'true_false' | 'short_answer';
 
@@ -92,8 +93,8 @@ function ResultsReviewInner() {
         );
         setData(response.data);
         setError(null);
-      } catch (err: any) {
-        setError(err.message || 'Failed to load review');
+      } catch (err) {
+        setError(getErrorMessage(err, 'Failed to load review'));
       } finally {
         setLoading(false);
       }

--- a/components/layout/OnboardingVideo.tsx
+++ b/components/layout/OnboardingVideo.tsx
@@ -33,6 +33,10 @@ export function OnboardingVideo() {
     }
     const dismissed = sessionStorage.getItem(DISMISS_KEY);
     if (dismissed) {
+      // Deliberately deferred to a client-only effect: sessionStorage isn't
+      // available during SSR, and setting this during the initial render
+      // would mismatch the server-rendered HTML. Must run after mount.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setIsDismissed(true);
       return;
     }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,15 @@
+/**
+ * Extracts a human-readable message from a caught value of unknown type.
+ * `catch` variables are `unknown` under strict mode -- this replaces the
+ * common but unsafe `catch (err: any) { ... err.message ... }` pattern,
+ * which assumes every thrown value is an Error without checking.
+ */
+export function getErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+  return fallback;
+}

--- a/lib/studentSkillRatings.ts
+++ b/lib/studentSkillRatings.ts
@@ -33,7 +33,7 @@ export interface CreateSkillRatingPayload {
   rating_value: number;
 }
 
-export interface UpdateSkillRatingPayload extends Partial<CreateSkillRatingPayload> {}
+export type UpdateSkillRatingPayload = Partial<CreateSkillRatingPayload>;
 
 function buildQuery(params: Record<string, string | number | undefined>) {
   const search = new URLSearchParams();

--- a/lib/teacherAssignments.ts
+++ b/lib/teacherAssignments.ts
@@ -23,8 +23,8 @@ export async function getCurrentTeacherAssignments(
 ): Promise<TeacherAssignments> {
   try {
     const [classAssignmentsResponse, subjectAssignmentsResponse] = await Promise.all([
-      apiFetch<any>(`${API_ROUTES.classTeachers}?session_id=${sessionId}&term_id=${termId}&per_page=500`),
-      apiFetch<any>(`${API_ROUTES.subjectTeacherAssignments}?session_id=${sessionId}&term_id=${termId}&per_page=500`),
+      apiFetch<{ data?: TeacherAssignmentItem[] }>(`${API_ROUTES.classTeachers}?session_id=${sessionId}&term_id=${termId}&per_page=500`),
+      apiFetch<{ data?: TeacherAssignmentItem[] }>(`${API_ROUTES.subjectTeacherAssignments}?session_id=${sessionId}&term_id=${termId}&per_page=500`),
     ]);
 
     return {


### PR DESCRIPTION
# Pull Request Template

## Description

Eliminates every `@typescript-eslint/no-explicit-any` error across the codebase (61 → 0), plus fixes several other real lint errors found in the same pass (missing `useMemo` dependency causing a stale-closure bug, raw `<a>` tags that should be `<Link>`, an unescaped entity, and three `set-state-in-effect` warnings — each individually judged legitimate or fixed). Excludes the two `rules-of-hooks` violations in the student-dashboard files, since those are handled separately in #71.

## Related Issue (Link to issue ticket)

Found while reviewing overall lint/format status across this project's repos — no existing ticket, add a Linear link if the team wants one.

## Motivation and Context

`any` isn't just a style nitpick — every one of these silently disabled TypeScript's ability to catch a real class of bugs (wrong property names, wrong types passed downstream). One of them, in fact, was hiding a real bug — see below.

## What was changed

**The `any` types (61 → 0):**

Most usage was one uniform pattern: `catch (err: any) { ... err.message ... }` — unsafe because it assumes every thrown value is an `Error` without checking. Added `lib/errors.ts` (`getErrorMessage(error, fallback)`) and mechanically converted 14 files to `catch (err)` (which is `unknown` under this repo's `strict` tsconfig) + `getErrorMessage()`, with **zero behavioral change** — verified via `pnpm build` that every route still compiles and the fallback strings are unchanged.

The rest were fixed individually against real, already-declared types rather than widened to something else vague:
- `lib/teacherAssignments.ts` — `apiFetch<any>` → the actual response shape
- `lib/studentSkillRatings.ts` — an empty `interface X extends Y {}` → `type X = Partial<Y>`
- `v14/class-skill-ratings` — `(type as any).description` etc. removed entirely; `SkillType` already declares these fields, the casts did nothing but suppress the checker
- `v19/assessment-components/.../cbt-link`, `.../structures`, `v19/assessment-structures` — typed `Promise.all` results against their real response shapes
- `v21/student-attendance` — `(metadata as any).comment` → `(metadata as Record<string, unknown>).comment` (metadata is genuinely dynamic JSON; `unknown` is the honest type here, not a specific interface)

**Found along the way — a real bug:** `v25/staff-dashboard/page.tsx`'s `summaryCards` memo reads `teacherRoleLabel` in its body but only listed `[data]` as a dependency. If `teacherRoleLabel` changed without `data` changing, the summary card would show a stale value. I only found this because the React Compiler's lint integration flagged it as "memoization could not be preserved" rather than a normal `exhaustive-deps` warning — worth knowing that error message can be pointing at a real correctness bug, not just a compiler limitation.

**Other fixes:**
- 4× raw `<a href="/v27/cbt/admin">` → `<Link>` (breaks client-side navigation otherwise)
- 1× unescaped `"` in assessment-structures
- 3× `set-state-in-effect`: each judged individually rather than blanket-suppressed — `OnboardingVideo.tsx` is a legitimate SSR-safe deferred read (sessionStorage isn't available server-side, so the state change has to happen post-mount to avoid a hydration mismatch); the other two are dependency-driven resets (`if (!sessionId) { setX(null); ... }`), the textbook-correct use of an effect. Each has an inline comment explaining why.
- Two type errors that only the **full** `pnpm build` caught — `tsc --noEmit` alone missed both. Worth knowing for future lint/type sweeps in this repo: don't rely on `tsc --noEmit` in isolation as a complete signal.

## How Has This Been Tested?

- `pnpm lint` — zero errors outside the two files owned by #71 (confirmed by diffing the error list against a run excluding those two files)
- `npx tsc --noEmit` — clean
- `pnpm build` — full production build succeeds, all routes compile (this caught 2 real type errors my initial pass missed — see above)
- Not manually tested in a browser — this is a large mechanical sweep across 21 files; recommend spot-checking the CBT admin pages and the two dashboards (`v10/dashboard`, `v25/staff-dashboard`) before merge, since those had the real logic touches (not just `any` → typed).

## Screenshots (if appropriate)

N/A — no intended visual change anywhere in this diff.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) — the stale `teacherRoleLabel` dependency is a real bug fix
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. — no test framework in this repo; correctness verified via build + manual review of each diff.
- [x] All new and existing tests passed. — N/A, but lint/typecheck/build all pass.
