### PR TITLE
fix: warn/confirm before Preview and Publish with unsaved changes

### DIFF
--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -329,6 +329,14 @@ export default function WebsiteManagementPage() {
 
   const handleOpenPreview = async () => {
     setPreviewError(null);
+
+    if (hasUnsavedChanges) {
+      setPreviewError(
+        "You have unsaved changes -- Preview only shows what's already saved. Click \"Save as Draft\" first, then Preview.",
+      );
+      return;
+    }
+
     setPreviewLoading(true);
     try {
       const link = await getPreviewLink();

--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -359,6 +359,24 @@ export default function WebsiteManagementPage() {
     }
   };
 
+  // Unlike Preview, Publish always saves the current form state -- it has
+  // no stale-data risk to warn about. This is a deliberate confirmation
+  // step instead: publishing goes live immediately, so a heads-up before
+  // that happens (especially with edits still uncommitted to a draft) is
+  // worth the extra click.
+  const handlePublishClick = () => {
+    if (
+      hasUnsavedChanges &&
+      !window.confirm(
+        "You have unsaved changes. Publishing will save and make these changes live immediately -- continue?",
+      )
+    ) {
+      return;
+    }
+
+    handleSave("published");
+  };
+
   return (
     <>
       <div className="breadcrumbs-area">
@@ -803,7 +821,7 @@ export default function WebsiteManagementPage() {
                       type="button"
                       className="btn-fill-lg bg-blue-dark btn-hover-yellow"
                       disabled={submittingStatus !== null}
-                      onClick={() => handleSave("published")}
+                      onClick={handlePublishClick}
                     >
                       {submittingStatus === "published"
                         ? "Publishing…"


### PR DESCRIPTION
# Pull Request Template

## Description

Two related guardrails for the Website Management form's unsaved-changes handling:

1. **Preview** now warns explicitly if there are unsaved changes, instead of silently showing the old already-saved draft with no explanation.
2. **Publish Website** now shows a confirmation dialog if there are unsaved changes before going live -- not because it's unsafe (Publish always saves current form state, unlike Preview), but because publishing is immediate and irreversible-feeling, so a deliberate "are you sure?" is worth the extra click.

## Related Issue (Link to issue ticket)

Not tracked as a filed issue -- found live: picking a new theme and clicking Preview right away kept showing the old theme with no explanation why.

## Motivation and Context

**Preview:** generates a signed link to whatever the backend already has stored -- it has no way to reflect an in-browser form change that hasn't been saved yet. A passive tooltip already existed on the button ("Shows the last saved draft, not unsaved changes"), but tooltips are easy to miss.

**Publish:** functionally safe with unsaved changes (confirmed -- it saves current form state directly, not a stale snapshot), but goes live immediately with no undo. Added a confirmation step for that reason alone, not because of a data-correctness bug.

## How Has This Been Tested?

Real, end-to-end, not just a compile check -- every claim below was verified live against a running local instance, checking the actual database state before/after, not just UI text:

**Preview:**
- Unsaved change -> Preview -> warning shown, no preview link fetched
- Saved -> Preview -> works exactly as before, no regression

**Publish:**
- Unsaved change -> Publish -> dismiss the confirm dialog -> nothing saved (checked the database directly: unchanged)
- Unsaved change -> Publish -> accept the confirm dialog -> saves and publishes correctly (checked the database directly: new value persisted, status published)

### Test Environment

- Node.js version: see `.nvmrc` / repo engines field
- pnpm version: see `packageManager` in `package.json`
- Browser: Brave (Chromium-based), driven via a real authenticated Puppeteer session against the local dev server, backend on `127.0.0.1:8000`

## Screenshots (if appropriate)

Not attached -- verified via console assertions and direct database checks during each Puppeteer run.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed. (`npx tsc --noEmit` clean; manual E2E as above)

## Notes for reviewers

`handleOpenPreview`'s warning reuses the `hasUnsavedChanges` memo already in this component. `handlePublishClick` is a new thin wrapper around the existing `handleSave("published")` call -- same save logic, just gated behind a native `window.confirm()` when there are unsaved changes. No new state introduced for either.
