### PR TITLE
fix: always confirm before publishing, not just when there are unsaved changes

### DIFF
--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -68,6 +68,7 @@ export default function WebsiteManagementPage() {
     useState<SchoolWebsiteStatus | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
+  const [showPublishConfirm, setShowPublishConfirm] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
@@ -359,21 +360,15 @@ export default function WebsiteManagementPage() {
     }
   };
 
-  // Unlike Preview, Publish always saves the current form state -- it has
-  // no stale-data risk to warn about. This is a deliberate confirmation
-  // step instead: publishing goes live immediately, so a heads-up before
-  // that happens (especially with edits still uncommitted to a draft) is
-  // worth the extra click.
+  // Publish always saves the current form state and goes live immediately,
+  // so every click gets a confirmation -- not just when there are unsaved
+  // changes -- to guard against accidental publishes in general.
   const handlePublishClick = () => {
-    if (
-      hasUnsavedChanges &&
-      !window.confirm(
-        "You have unsaved changes. Publishing will save and make these changes live immediately -- continue?",
-      )
-    ) {
-      return;
-    }
+    setShowPublishConfirm(true);
+  };
 
+  const handleConfirmPublish = () => {
+    setShowPublishConfirm(false);
     handleSave("published");
   };
 
@@ -857,6 +852,61 @@ export default function WebsiteManagementPage() {
           reserved.
         </div>
       </footer>
+
+      {showPublishConfirm ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Confirm publish"
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 1060,
+            background: "rgba(15, 23, 42, 0.6)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "2rem",
+          }}
+          onClick={() => setShowPublishConfirm(false)}
+        >
+          <div
+            style={{
+              background: "#fff",
+              borderRadius: 12,
+              width: "100%",
+              maxWidth: 480,
+              padding: "1.5rem",
+            }}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h5 className="mb-3">Publish this website?</h5>
+            <p className="mb-4">
+              {hasUnsavedChanges
+                ? "You have unsaved changes. Publishing will save them and make the website live immediately."
+                : "This will make the website live immediately."}
+            </p>
+            <div className="d-flex justify-content-end" style={{ gap: 8 }}>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => setShowPublishConfirm(false)}
+                disabled={submittingStatus !== null}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn-fill-lg bg-blue-dark btn-hover-yellow"
+                onClick={handleConfirmPublish}
+                disabled={submittingStatus !== null}
+              >
+                {submittingStatus === "published" ? "Publishing…" : "Yes, publish"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       {previewUrl ? (
         <div


### PR DESCRIPTION
# Pull Request Template

## Description

The previous "confirm before publish" logic (merged in #75) only showed a confirmation when `hasUnsavedChanges` was true, using a bare `window.confirm()`. That left the common case -- clicking Publish on an already-saved draft -- with zero confirmation at all, which is exactly the accidental-publish scenario worth guarding against. Replaced it with an in-app modal (matching this page's existing Preview modal styling) that shows on every publish click, with the message text adjusted depending on whether there are unsaved changes.

## Related Issue (Link to issue ticket)

Follow-up to #75 -- found during manual verification that the confirmation only fired conditionally, not on every publish.

## Motivation and Context

Publishing goes live immediately with no undo. A confirmation that only sometimes appears is easy to click past without noticing, defeating the point of having a safety check at all.

## How Has This Been Tested?

- Manually verified: clicking Publish with no unsaved changes now shows the modal (previously published immediately, no confirmation)
- Manually verified: clicking Publish with unsaved changes shows the modal with the unsaved-changes-specific message
- Cancel closes the modal without saving/publishing
- Confirm saves and publishes correctly
- `npx tsc --noEmit` and `npm run build` clean

## Screenshots (if appropriate)

N/A -- modal matches the existing Preview modal's styling on this page (inline-styled overlay, not a new visual pattern).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.