### PR TITLE
feat: sticky unified action bar for Website Management

### DIFF
--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -400,61 +400,137 @@ export default function WebsiteManagementPage() {
         </div>
       ) : null}
 
+      <div
+        style={{
+          position: "sticky",
+          top: 0,
+          zIndex: 500,
+          background: "#fff",
+          boxShadow: "0 2px 8px rgba(15, 23, 42, 0.08)",
+          borderRadius: 8,
+          padding: "1rem 1.25rem",
+          marginBottom: "1.5rem",
+        }}
+      >
+        <div className="d-flex align-items-center justify-content-between flex-wrap" style={{ gap: 12 }}>
+          <div>
+            <h3 className="mb-0">
+              Website Status:{" "}
+              <span className={STATUS_BADGE_CLASS[status]}>
+                {STATUS_LABELS[status]}
+              </span>
+            </h3>
+            {publishedAt ? (
+              <p className="mb-0">
+                Last published {new Date(publishedAt).toLocaleString()}
+              </p>
+            ) : null}
+            {hasUnsavedChanges ? (
+              <span className="text-warning">You have unsaved changes.</span>
+            ) : null}
+          </div>
+          <div
+            className="d-flex align-items-center flex-wrap"
+            style={{ gap: 20 }}
+          >
+            {/* Secondary/utility actions -- smaller, outline style, demoted
+                relative to the primary Save/Publish actions below. */}
+            <div className="d-flex align-items-center flex-wrap" style={{ gap: 8 }}>
+              <button
+                type="button"
+                className="btn-fill-sm"
+                style={{ color: "#172033", background: "#f1f5f9" }}
+                onClick={handleOpenPreview}
+                disabled={previewLoading || status === "unconfigured"}
+                title={
+                  status === "unconfigured"
+                    ? "Save as Draft first, then Preview"
+                    : "Shows the last saved draft, not unsaved changes"
+                }
+              >
+                {previewLoading ? "Loading Preview…" : "Preview"}
+              </button>
+              {publicUrl ? (
+                <a
+                  href={publicUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="btn-fill-sm"
+                  style={{ color: "#172033", background: "#f1f5f9" }}
+                >
+                  View Public Website
+                </a>
+              ) : (
+                <p className="mb-0 text-muted">
+                  Public website link unavailable (school has no slug yet).
+                </p>
+              )}
+            </div>
+
+            {canManage ? (
+              <div className="d-flex align-items-center flex-wrap" style={{ gap: 8 }}>
+                {/* Primary actions -- full size, solid fill, most visually prominent. */}
+                <button
+                  type="submit"
+                  form="website-management-form"
+                  className="btn-fill-lg btn-gradient-yellow btn-hover-bluedark"
+                  disabled={submittingStatus !== null}
+                >
+                  {submittingStatus === "draft" ? "Saving…" : "Save as Draft"}
+                </button>
+                <button
+                  type="button"
+                  className="btn-fill-lg bg-blue-dark btn-hover-yellow"
+                  disabled={submittingStatus !== null}
+                  onClick={handlePublishClick}
+                >
+                  {submittingStatus === "published"
+                    ? "Publishing…"
+                    : "Publish Website"}
+                </button>
+                {status === "published" ? (
+                  // Destructive, rarely-used action -- deliberately smaller
+                  // and muted, and set apart with extra left margin so it
+                  // doesn't visually compete with Save/Publish.
+                  <button
+                    type="button"
+                    className="btn-fill-sm"
+                    style={{
+                      color: "#b91c1c",
+                      background: "#fee2e2",
+                      marginLeft: 12,
+                    }}
+                    disabled={submittingStatus !== null}
+                    onClick={() => handleSave("unpublished")}
+                  >
+                    {submittingStatus === "unpublished"
+                      ? "Unpublishing…"
+                      : "Unpublish Website"}
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {previewError ? (
+          <div className="alert alert-danger mt-3 mb-0" role="alert">
+            {previewError}
+          </div>
+        ) : null}
+
+        {!canManage ? (
+          <p className="text-muted mt-3 mb-0">
+            You have read-only access to Website Management and cannot save
+            changes.
+          </p>
+        ) : null}
+      </div>
+
       <div className="row">
         <div className="col-12">
           <div className="card">
             <div className="card-body">
-              <div className="heading-layout1">
-                <div className="item-title">
-                  <h3>
-                    Website Status:{" "}
-                    <span className={STATUS_BADGE_CLASS[status]}>
-                      {STATUS_LABELS[status]}
-                    </span>
-                  </h3>
-                  {publishedAt ? (
-                    <p className="mb-0">
-                      Last published {new Date(publishedAt).toLocaleString()}
-                    </p>
-                  ) : null}
-                </div>
-                <div className="d-flex align-items-center" style={{ gap: 8 }}>
-                  <button
-                    type="button"
-                    className="btn-fill-lg btn-gradient-yellow btn-hover-bluedark"
-                    onClick={handleOpenPreview}
-                    disabled={previewLoading || status === "unconfigured"}
-                    title={
-                      status === "unconfigured"
-                        ? "Save as Draft first, then Preview"
-                        : "Shows the last saved draft, not unsaved changes"
-                    }
-                  >
-                    {previewLoading ? "Loading Preview…" : "Preview"}
-                  </button>
-                  {publicUrl ? (
-                    <a
-                      href={publicUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="btn-fill-lg bg-blue-dark btn-hover-yellow"
-                    >
-                      View Public Website
-                    </a>
-                  ) : (
-                    <p className="mb-0 text-muted">
-                      Public website link unavailable (school has no slug yet).
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              {previewError ? (
-                <div className="alert alert-danger mt-3" role="alert">
-                  {previewError}
-                </div>
-              ) : null}
-
               <form
                 id="website-management-form"
                 className="new-added-form"
@@ -796,51 +872,6 @@ export default function WebsiteManagementPage() {
                   </div>
                 </div>
 
-                {!canManage ? (
-                  <p className="text-muted mt-3">
-                    You have read-only access to Website Management and cannot
-                    save changes.
-                  </p>
-                ) : (
-                  <div className="col-12 form-group mg-t-8">
-                    <button
-                      type="submit"
-                      className="btn-fill-lg btn-gradient-yellow btn-hover-bluedark"
-                      disabled={submittingStatus !== null}
-                    >
-                      {submittingStatus === "draft"
-                        ? "Saving…"
-                        : "Save as Draft"}
-                    </button>
-                    <button
-                      type="button"
-                      className="btn-fill-lg bg-blue-dark btn-hover-yellow"
-                      disabled={submittingStatus !== null}
-                      onClick={handlePublishClick}
-                    >
-                      {submittingStatus === "published"
-                        ? "Publishing…"
-                        : "Publish Website"}
-                    </button>
-                    {status === "published" ? (
-                      <button
-                        type="button"
-                        className="btn-fill-lg bg-dark-pastel-green btn-hover-yellow"
-                        disabled={submittingStatus !== null}
-                        onClick={() => handleSave("unpublished")}
-                      >
-                        {submittingStatus === "unpublished"
-                          ? "Unpublishing…"
-                          : "Unpublish Website"}
-                      </button>
-                    ) : null}
-                    {hasUnsavedChanges ? (
-                      <span className="text-warning ml-2">
-                        You have unsaved changes.
-                      </span>
-                    ) : null}
-                  </div>
-                )}
               </form>
             </div>
           </div>
@@ -889,7 +920,11 @@ export default function WebsiteManagementPage() {
             <div className="d-flex justify-content-end" style={{ gap: 8 }}>
               <button
                 type="button"
-                className="btn btn-secondary"
+                className="btn-fill-lg"
+                style={{
+                  color: "#172033",
+                  background: "#f1f5f9",
+                }}
                 onClick={() => setShowPublishConfirm(false)}
                 disabled={submittingStatus !== null}
               >


### PR DESCRIPTION
# Pull Request Template

## Description

Stacked on #76. The lifecycle actions were split across the page -- status badge, Preview and View Public Website sat in a header at the top, while Save as Draft, Publish and Unpublish sat at the very bottom, after a scrolling form. Editing a field near the top meant scrolling all the way down to save, then back up to preview -- poor spatial locality, and a deviation from the original Phase 6 / SWT-008 design intent (a tabbed interface specifically meant to avoid a single giant scrolling form).

Merged both into one bar, pinned to the top of the viewport via `position: sticky`, so it stays visible regardless of scroll position.

Also established visual hierarchy instead of five equally-styled buttons competing for attention:
- **Save as Draft** and **Publish Website** stay full-size/solid as the primary actions
- **Preview** and **View Public Website** demote to smaller, light-filled secondary buttons
- **Unpublish Website** (destructive, rarely used) is smaller still, muted red, and set apart with extra spacing so it doesn't sit next to Publish by accident

## Related Issue (Link to issue ticket)

Follow-up UX fix raised during manual verification of #75/#76 -- no tracked issue.

## Motivation and Context

Direct feedback that the split top/bottom action layout wasn't a great pattern for a form this size, and didn't match modern site-editor conventions (Webflow/Framer/WordPress use a persistent action bar).

## How Has This Been Tested?

- Manually verified the bar stays pinned while scrolling through Theme/Branding/Header/Hero fields
- Manually verified Save as Draft still submits correctly via the `form` attribute now that it's outside the `<form>` DOM element
- Manually verified Publish/Unpublish still work from the new bar
- Checked button layout uses `flex-wrap` throughout with no fixed widths, so it wraps rather than overflows on narrow viewports
- `npx tsc --noEmit` and `npm run build` clean

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.