### PR TITLE
feat: add section-visibility toggles and tabbed layout to Website Management

### DIFF
--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -69,8 +69,8 @@ export default function WebsiteManagementPage() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const [activeTab, setActiveTab] = useState<
-    "theme" | "branding" | "homepage" | "sections"
-  >("theme");
+    "branding" | "homepage" | "sections"
+  >("branding");
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
@@ -492,7 +492,6 @@ export default function WebsiteManagementPage() {
                 >
                   {(
                     [
-                      ["theme", "Theme"],
                       ["branding", "Branding"],
                       ["homepage", "Homepage"],
                       ["sections", "Sections"],
@@ -524,7 +523,7 @@ export default function WebsiteManagementPage() {
                   All fields are required unless marked (optional).
                 </p>
 
-                <div style={{ display: activeTab === "theme" ? "block" : "none" }}>
+                <div style={{ display: activeTab === "branding" ? "block" : "none" }}>
                 <div className="row">
                   <div className="col-lg-6 col-12 form-group">
                     <label htmlFor="website-theme-key">Website Theme</label>
@@ -548,9 +547,6 @@ export default function WebsiteManagementPage() {
                     ) : null}
                   </div>
                 </div>
-                </div>
-
-                <div style={{ display: activeTab === "branding" ? "block" : "none" }}>
                 <div className="row">
                   <div className="col-lg-6 col-12 form-group">
                     <label htmlFor="branding-primary-color">Primary Colour</label>

--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -68,6 +68,9 @@ export default function WebsiteManagementPage() {
     useState<SchoolWebsiteStatus | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
+  const [activeTab, setActiveTab] = useState<
+    "theme" | "branding" | "homepage" | "sections"
+  >("theme");
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
@@ -250,6 +253,20 @@ export default function WebsiteManagementPage() {
     });
   };
 
+  const updateEnabledSection = (
+    key: keyof SchoolWebsitePayload["enabledSections"],
+    value: boolean,
+  ) => {
+    setForm((prev) =>
+      prev
+        ? {
+            ...prev,
+            enabledSections: { ...prev.enabledSections, [key]: value },
+          }
+        : prev,
+    );
+  };
+
   const fieldError = (key: string): string | null => {
     const messages = fieldErrors?.[key];
     return messages && messages.length > 0 ? messages[0] : null;
@@ -283,6 +300,10 @@ export default function WebsiteManagementPage() {
     const payload: SchoolWebsitePayload = {
       ...form,
       hero: { ...form.hero, title: heroTitle, trustItems },
+      // Main Banner (hero) isn't optional -- there's no UI to turn it off,
+      // so force it true here too in case an older record was saved with
+      // it false before that control was removed.
+      enabledSections: { ...form.enabledSections, hero: true },
       seo: {
         ...form.seo,
         title: heroTitle,
@@ -465,10 +486,48 @@ export default function WebsiteManagementPage() {
                 className="new-added-form"
                 onSubmit={handleSubmit}
               >
-                <h4 className="mt-4">Theme</h4>
+                <div
+                  className="d-flex flex-wrap"
+                  style={{ gap: 8, borderBottom: "1px solid #e2e8f0", paddingBottom: "1rem" }}
+                >
+                  {(
+                    [
+                      ["theme", "Theme"],
+                      ["branding", "Branding"],
+                      ["homepage", "Homepage"],
+                      ["sections", "Sections"],
+                    ] as const
+                  ).map(([key, label]) => (
+                    <button
+                      key={key}
+                      type="button"
+                      className="btn-fill-sm"
+                      style={
+                        activeTab === key
+                          ? { color: "#fff", background: "#172033", fontWeight: 700 }
+                          : { color: "#172033", background: "#f1f5f9", fontWeight: 700 }
+                      }
+                      onClick={() => setActiveTab(key)}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+
+                <style>{`
+                  #website-management-form label:not(.custom-control-label) {
+                    font-weight: 600;
+                    color: #172033;
+                  }
+                `}</style>
+                <p className="text-muted mt-3 mb-0" style={{ fontSize: "0.85rem" }}>
+                  All fields are required unless marked (optional).
+                </p>
+
+                <div style={{ display: activeTab === "theme" ? "block" : "none" }}>
                 <div className="row">
                   <div className="col-lg-6 col-12 form-group">
-                    <label htmlFor="website-theme-key">Website Theme *</label>
+                    <label htmlFor="website-theme-key">Website Theme</label>
                     <select
                       id="website-theme-key"
                       className="form-control"
@@ -489,11 +548,12 @@ export default function WebsiteManagementPage() {
                     ) : null}
                   </div>
                 </div>
+                </div>
 
-                <h4 className="mt-4">Branding</h4>
+                <div style={{ display: activeTab === "branding" ? "block" : "none" }}>
                 <div className="row">
                   <div className="col-lg-6 col-12 form-group">
-                    <label htmlFor="branding-primary-color">Primary Colour *</label>
+                    <label htmlFor="branding-primary-color">Primary Colour</label>
                     <div className="d-flex align-items-center">
                       <input
                         id="branding-primary-color"
@@ -523,7 +583,7 @@ export default function WebsiteManagementPage() {
                   </div>
                   <div className="col-lg-6 col-12 form-group">
                     <label htmlFor="branding-secondary-color">
-                      Secondary Colour *
+                      Secondary Colour
                     </label>
                     <div className="d-flex align-items-center">
                       <input
@@ -553,11 +613,12 @@ export default function WebsiteManagementPage() {
                     ) : null}
                   </div>
                 </div>
+                </div>
 
-                <h4 className="mt-4">Header</h4>
+                <div style={{ display: activeTab === "homepage" ? "block" : "none" }}>
                 <div className="row">
                   <div className="col-lg-4 col-12 form-group">
-                    <label htmlFor="header-welcome-text">Welcome Text *</label>
+                    <label htmlFor="header-welcome-text">Welcome Text</label>
                     <input
                       id="header-welcome-text"
                       type="text"
@@ -570,7 +631,7 @@ export default function WebsiteManagementPage() {
                     />
                   </div>
                   <div className="col-lg-4 col-12 form-group">
-                    <label htmlFor="header-utility-text">Utility Text *</label>
+                    <label htmlFor="header-utility-text">Utility Text</label>
                     <input
                       id="header-utility-text"
                       type="text"
@@ -583,7 +644,7 @@ export default function WebsiteManagementPage() {
                     />
                   </div>
                   <div className="col-lg-4 col-12 form-group">
-                    <label htmlFor="header-tagline">Tagline *</label>
+                    <label htmlFor="header-tagline">Tagline</label>
                     <input
                       id="header-tagline"
                       type="text"
@@ -597,10 +658,9 @@ export default function WebsiteManagementPage() {
                   </div>
                 </div>
 
-                <h4 className="mt-4">Hero</h4>
                 <div className="row">
                   <div className="col-lg-6 col-12 form-group">
-                    <label htmlFor="hero-eyebrow">Eyebrow *</label>
+                    <label htmlFor="hero-eyebrow">Eyebrow</label>
                     <input
                       id="hero-eyebrow"
                       type="text"
@@ -613,7 +673,7 @@ export default function WebsiteManagementPage() {
                     />
                   </div>
                   <div className="col-lg-6 col-12 form-group">
-                    <label htmlFor="hero-title">Title *</label>
+                    <label htmlFor="hero-title">Title</label>
                     <input
                       id="hero-title"
                       type="text"
@@ -624,7 +684,7 @@ export default function WebsiteManagementPage() {
                     />
                   </div>
                   <div className="col-12 form-group">
-                    <label htmlFor="hero-description">Description *</label>
+                    <label htmlFor="hero-description">Description</label>
                     <textarea
                       id="hero-description"
                       className="textarea form-control"
@@ -637,7 +697,9 @@ export default function WebsiteManagementPage() {
                     />
                   </div>
                   <div className="col-12 form-group">
-                    <label htmlFor="hero-image-url">Hero Image URL</label>
+                    <label htmlFor="hero-image-url">
+                      Hero Image URL <span style={{ fontWeight: 400, color: "#6c757d" }}>(optional)</span>
+                    </label>
                     <input
                       id="hero-image-url"
                       type="url"
@@ -656,7 +718,7 @@ export default function WebsiteManagementPage() {
 
                   <div className="col-lg-6 col-12 form-group">
                     <label htmlFor="hero-primary-action-label">
-                      Primary Action Label *
+                      Primary Action Label
                     </label>
                     <input
                       id="hero-primary-action-label"
@@ -675,7 +737,7 @@ export default function WebsiteManagementPage() {
                   </div>
                   <div className="col-lg-6 col-12 form-group">
                     <label htmlFor="hero-primary-action-href">
-                      Primary Action Link *
+                      Primary Action Link
                     </label>
                     <input
                       id="hero-primary-action-href"
@@ -694,7 +756,7 @@ export default function WebsiteManagementPage() {
                   </div>
                   <div className="col-lg-6 col-12 form-group">
                     <label htmlFor="hero-secondary-action-label">
-                      Secondary Action Label *
+                      Secondary Action Label
                     </label>
                     <input
                       id="hero-secondary-action-label"
@@ -713,7 +775,7 @@ export default function WebsiteManagementPage() {
                   </div>
                   <div className="col-lg-6 col-12 form-group">
                     <label htmlFor="hero-secondary-action-href">
-                      Secondary Action Link *
+                      Secondary Action Link
                     </label>
                     <input
                       id="hero-secondary-action-href"
@@ -732,7 +794,7 @@ export default function WebsiteManagementPage() {
                   </div>
 
                   <div className="col-12 form-group">
-                    <label>Trust Items *</label>
+                    <label>Trust Items</label>
                     <div className="row">
                       {[0, 1, 2].map((index) => (
                         <div className="col-lg-4 col-12" key={index}>
@@ -756,7 +818,7 @@ export default function WebsiteManagementPage() {
 
                   <div className="col-lg-4 col-12 form-group">
                     <label htmlFor="hero-info-card-label">
-                      Info Card Label *
+                      Info Card Label
                     </label>
                     <input
                       id="hero-info-card-label"
@@ -771,7 +833,7 @@ export default function WebsiteManagementPage() {
                   </div>
                   <div className="col-lg-4 col-12 form-group">
                     <label htmlFor="hero-info-card-title">
-                      Info Card Title *
+                      Info Card Title
                     </label>
                     <input
                       id="hero-info-card-title"
@@ -786,7 +848,7 @@ export default function WebsiteManagementPage() {
                   </div>
                   <div className="col-lg-4 col-12 form-group">
                     <label htmlFor="hero-info-card-description">
-                      Info Card Description *
+                      Info Card Description
                     </label>
                     <input
                       id="hero-info-card-description"
@@ -799,6 +861,66 @@ export default function WebsiteManagementPage() {
                       required
                     />
                   </div>
+                </div>
+                </div>
+
+                <div style={{ display: activeTab === "sections" ? "block" : "none" }}>
+                <h4 className="mt-4">Sections</h4>
+                <p className="text-muted mb-3">
+                  Turn sections on or off on the public website. These
+                  sections will move to their own tabs too once their
+                  editors are built.
+                </p>
+                <div
+                  style={{
+                    border: "1px solid #e2e8f0",
+                    borderRadius: 8,
+                    overflow: "hidden",
+                  }}
+                >
+                  {(
+                    [
+                      ["highlights", "Highlights", "No editor yet -- shows placeholder content"],
+                      ["about", "About", "No editor yet -- shows placeholder content"],
+                      ["programmes", "Programmes", "No editor yet -- shows placeholder content"],
+                      ["admissions", "Admissions", "No editor yet -- shows placeholder content"],
+                      ["contact", "Contact", "No editor yet -- shows placeholder content"],
+                    ] as const
+                  ).map(([key, label, note], index) => (
+                    <label
+                      key={key}
+                      htmlFor={`enabled-section-${key}`}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        gap: 12,
+                        padding: "0.85rem 1rem",
+                        borderTop: index === 0 ? undefined : "1px solid #e2e8f0",
+                        cursor: "pointer",
+                      }}
+                    >
+                      <div>
+                        <div style={{ fontWeight: 600, color: "#212529" }}>
+                          {label}
+                        </div>
+                        {note ? (
+                          <small style={{ color: "#6c757d" }}>{note}</small>
+                        ) : null}
+                      </div>
+                      <input
+                        type="checkbox"
+                        className="permission-checkbox"
+                        id={`enabled-section-${key}`}
+                        checked={form.enabledSections[key]}
+                        onChange={(event) =>
+                          updateEnabledSection(key, event.target.checked)
+                        }
+                        style={{ flexShrink: 0 }}
+                      />
+                    </label>
+                  ))}
+                </div>
                 </div>
 
                 {!canManage ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,7 @@ body {
   min-height: 100%;
 }
 /* Permission toggle styling for permission toggles on role/permission pages */
-.custom-control-input.permission-checkbox {
+.permission-checkbox {
   position: relative;
   width: 54px;
   height: 28px;
@@ -15,10 +15,10 @@ body {
   border: 0;
   transition: background .2s ease;
 }
-.custom-control-input.permission-checkbox:checked {
+.permission-checkbox:checked {
   background-color: #0d6efd;
 }
-.custom-control-input.permission-checkbox:before {
+.permission-checkbox:before {
   content: "";
   position: absolute;
   width: 22px;
@@ -29,7 +29,7 @@ body {
   background: white;
   transition: transform .2s ease;
 }
-.custom-control-input.permission-checkbox:checked:before {
+.permission-checkbox:checked:before {
   transform: translateX(26px);
 }
 
@@ -59,24 +59,24 @@ body {
   color: #6c757d;
 }
 /* Improve focus ring for keyboard users */
-.custom-control-input.permission-checkbox:focus-visible {
+.permission-checkbox:focus-visible {
   box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.18);
   outline: none;
 }
 /* Disabled/locked appearance */
-.custom-control-input.permission-checkbox[disabled] {
+.permission-checkbox[disabled] {
   opacity: 0.6;
   cursor: not-allowed;
 }
-.custom-control-input.permission-checkbox[disabled]:before {
+.permission-checkbox[disabled]:before {
   background: #f8f9fa;
 }
 /* Make sure label stacks nicely next to the toggle */
-.custom-control-input.permission-checkbox + .custom-control-label {
+.permission-checkbox + .custom-control-label {
   display: flex;
   flex-direction: column;
 }
-.custom-control-input.permission-checkbox + .custom-control-label .text-muted {
+.permission-checkbox + .custom-control-label .text-muted {
   margin-left: 0;
 }
 
@@ -87,17 +87,17 @@ body {
 
 /* Slightly larger hit target on small screens */
 @media (max-width: 576px) {
-  .custom-control-input.permission-checkbox {
+  .permission-checkbox {
     width: 46px;
     height: 26px;
   }
-  .custom-control-input.permission-checkbox:before {
+  .permission-checkbox:before {
     width: 20px;
     height: 20px;
     left: 3px;
     top: 3px;
   }
-  .custom-control-input.permission-checkbox:checked:before {
+  .permission-checkbox:checked:before {
     transform: translateX(20px);
   }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Adds the `enabledSections` toggle UI required by SWT-008's acceptance criteria -- previously the only way to change these flags was a direct database write. Also restructures the page into tabs (Theme / Branding / Homepage / Sections) instead of one long scrolling form, matching the original Phase 6 design intent that a single flat form was deviating from.

- New **Sections** tab: pill toggle switches (reusing `globals.css`'s previously-unused `.permission-checkbox` styling, originally built for a permissions page but never wired up anywhere) for Highlights, About, Programmes, Admissions, Contact -- each notes it has no editor yet and shows placeholder content until one is built.
- Fixed a real CSS bug found while building this: combining Bootstrap's `.custom-control-input` (`position: absolute; opacity: 0`, meant to pair with `::before`/`::after` pseudo-elements) with the standalone `.permission-checkbox` system produced an invisible/broken toggle. Simplified `globals.css`'s selector to target `.permission-checkbox` alone so it works standalone.
- Main Banner (hero) is not optional -- unlike the other sections, an empty homepage banner isn't a reasonable state, so it has no toggle and is force-set `true` on every save (self-healing any legacy record saved `false` before this was decided).
- Flipped the required-field convention: 16 of 22 fields on this page are required, so marking the required majority with `*` on every label was the wrong default. Now only the 1 genuinely optional field (hero image URL) is marked "(optional)", with one legend line explaining the convention instead of repeating `*` everywhere.
- Field labels and tab buttons now bold for legibility.

## Related Issue (Link to issue ticket)

SWT-008 acceptance criteria (section-toggle UI was the one item never actually built).

## Motivation and Context

The `enabledSections` field already existed in the data contract and the public themes already read it correctly, but the admin form had no UI for it at all -- the only way to flip a section was a direct database write. Also fixes a real UX gap: lifecycle actions and field groups were all crammed into one long scrolling form with no way to jump between sections.

## How Has This Been Tested?

- Manually verified each of the 5 section toggles saves and is reflected in the public-web Preview (toggle -> Save as Draft -> Preview)
- Manually verified tab switching preserves unsaved edits across tabs (data lives in one shared form object, not per-tab state)
- Manually verified Save as Draft/Publish still submit the whole form regardless of which tab is active
- Manually verified the toggle switches render correctly (not the earlier broken/invisible version)
- `npx tsc --noEmit` and `npm run build` clean

## Screenshots (if appropriate)

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.