### PR TITLE
feat: add About section editor to Website Management

### DIFF
--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -69,7 +69,7 @@ export default function WebsiteManagementPage() {
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const [activeTab, setActiveTab] = useState<
-    "branding" | "homepage" | "sections"
+    "branding" | "homepage" | "about" | "sections"
   >("branding");
   const [showPublishConfirm, setShowPublishConfirm] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -201,6 +201,23 @@ export default function WebsiteManagementPage() {
             ...prev,
             hero: {
               ...prev.hero,
+              [key]: key === "imageUrl" ? value || null : value,
+            },
+          }
+        : prev,
+    );
+  };
+
+  const updateAbout = (
+    key: "eyebrow" | "title" | "description" | "imageUrl" | "mission" | "vision",
+    value: string,
+  ) => {
+    setForm((prev) =>
+      prev
+        ? {
+            ...prev,
+            about: {
+              ...prev.about,
               [key]: key === "imageUrl" ? value || null : value,
             },
           }
@@ -489,6 +506,7 @@ export default function WebsiteManagementPage() {
                     [
                       ["branding", "Branding"],
                       ["homepage", "Homepage"],
+                      ["about", "About"],
                       ["sections", "Sections"],
                     ] as const
                   ).map(([key, label]) => (
@@ -855,6 +873,118 @@ export default function WebsiteManagementPage() {
                 </div>
                 </div>
 
+                <div style={{ display: activeTab === "about" ? "block" : "none" }}>
+                <div className="d-flex align-items-center justify-content-between mt-4">
+                  <h4 className="mb-0">About</h4>
+                  <label
+                    htmlFor="enabled-section-about"
+                    style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer" }}
+                  >
+                    <span style={{ fontWeight: 600, color: "#212529" }}>
+                      Show About section
+                    </span>
+                    <input
+                      type="checkbox"
+                      className="permission-checkbox"
+                      id="enabled-section-about"
+                      checked={form.enabledSections.about}
+                      onChange={(event) =>
+                        updateEnabledSection("about", event.target.checked)
+                      }
+                    />
+                  </label>
+                </div>
+                <div
+                  className="row"
+                  style={
+                    form.enabledSections.about
+                      ? undefined
+                      : { opacity: 0.5, pointerEvents: "none" }
+                  }
+                >
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="about-eyebrow">Eyebrow</label>
+                    <input
+                      id="about-eyebrow"
+                      type="text"
+                      className="form-control"
+                      value={form.about.eyebrow}
+                      onChange={(event) =>
+                        updateAbout("eyebrow", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="about-title">Title</label>
+                    <input
+                      id="about-title"
+                      type="text"
+                      className="form-control"
+                      value={form.about.title}
+                      onChange={(event) =>
+                        updateAbout("title", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-12 form-group">
+                    <label htmlFor="about-description">Description</label>
+                    <textarea
+                      id="about-description"
+                      className="textarea form-control"
+                      rows={4}
+                      value={form.about.description}
+                      onChange={(event) =>
+                        updateAbout("description", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-12 form-group">
+                    <label htmlFor="about-image-url">
+                      About Image URL <span style={{ fontWeight: 400, color: "#6c757d" }}>(optional)</span>
+                    </label>
+                    <input
+                      id="about-image-url"
+                      type="url"
+                      className="form-control"
+                      value={form.about.imageUrl ?? ""}
+                      onChange={(event) =>
+                        updateAbout("imageUrl", event.target.value)
+                      }
+                      placeholder="https://example.com/about.jpg"
+                    />
+                  </div>
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="about-mission">Mission</label>
+                    <textarea
+                      id="about-mission"
+                      className="textarea form-control"
+                      rows={3}
+                      value={form.about.mission}
+                      onChange={(event) =>
+                        updateAbout("mission", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="col-lg-6 col-12 form-group">
+                    <label htmlFor="about-vision">Vision</label>
+                    <textarea
+                      id="about-vision"
+                      className="textarea form-control"
+                      rows={3}
+                      value={form.about.vision}
+                      onChange={(event) =>
+                        updateAbout("vision", event.target.value)
+                      }
+                      required
+                    />
+                  </div>
+                </div>
+                </div>
+
                 <div style={{ display: activeTab === "sections" ? "block" : "none" }}>
                 <h4 className="mt-4">Sections</h4>
                 <p className="text-muted mb-3">
@@ -872,7 +1002,6 @@ export default function WebsiteManagementPage() {
                   {(
                     [
                       ["highlights", "Highlights", "No editor yet -- shows placeholder content"],
-                      ["about", "About", "No editor yet -- shows placeholder content"],
                       ["programmes", "Programmes", "No editor yet -- shows placeholder content"],
                       ["admissions", "Admissions", "No editor yet -- shows placeholder content"],
                       ["contact", "Contact", "No editor yet -- shows placeholder content"],


### PR DESCRIPTION
# Pull Request Template

## Description

Adds an editor for the About section -- the first of the four remaining content editors (About, Admissions, Contact, Programmes & Highlights, per the roadmap's suggested order). New "About" tab with fields for eyebrow, title, description, image URL, mission, and vision, mirroring the existing Hero field pattern exactly.

## Related Issue (Link to issue ticket)

Roadmap section 30.A (notes/ROADMAP.md) -- content editors are the one remaining real gap in Website Management.

## Motivation and Context

`enabledSections.about` already existed and the public themes already read it correctly, but toggling it on only ever showed hardcoded placeholder text -- there was no form anywhere to enter real About content. This ships the first of the four editors needed to make that toggle actually useful.

## How Has This Been Tested?

- Manually verified: edited all six About fields, saved as draft, reloaded the page, confirmed values persisted
- Manually verified: toggled About off, fields visibly grey out and become unclickable; toggled back on, fully usable again
- Manually verified: toggled About on, saved, checked Preview -- About content renders correctly on the public site instead of being hidden
- Manually verified: Sections tab no longer lists "About" (moved to its own tab)
- `npx tsc --noEmit` and `npm run build` clean

## Screenshots (if appropriate)

<img width="1135" height="761" alt="image" src="https://github.com/user-attachments/assets/9efcfa79-48a3-4fef-bb9c-92b9acbe7394" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.