### PR TITLE
feat: add Go Live button to Website Management

### DIFF
--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -112,6 +112,11 @@ export default function WebsiteManagementPage() {
       .catch((error) => {
         if (!cancelled) {
           console.error("Failed to load Go Live status", error);
+          setGoLiveError(
+            error instanceof Error
+              ? error.message
+              : "Unable to check Go Live status. Please refresh the page.",
+          );
         }
       })
       .finally(() => {
@@ -633,8 +638,8 @@ export default function WebsiteManagementPage() {
       setGoLiveRequest(request);
       showToast(
         goLiveRequest
-          ? "Resent -- we've notified our team again."
-          : "Go Live request sent -- we'll notify you once your website is live.",
+          ? "Resent -- we have notified our team again."
+          : "Go Live request sent -- we will notify you once your website is live.",
       );
     } catch (error) {
       console.error("Failed to request Go Live", error);
@@ -642,7 +647,7 @@ export default function WebsiteManagementPage() {
         setGoLiveError(error.message);
       } else if (error instanceof GoLiveCooldownError) {
         setGoLiveError(
-          "You'll be able to resend 48 hours after your last request.",
+          "You will be able to resend 48 hours after your last request.",
         );
       } else if (error instanceof ApiError && error.status === 409) {
         // Already activated server-side (e.g. approved moments ago) --
@@ -717,22 +722,56 @@ export default function WebsiteManagementPage() {
             <div className="card-body">
               <div className="heading-layout1">
                 <div className="item-title">
-                  <h3>
+                  <h3 className="mb-1">
                     Website Status:{" "}
                     <span className={STATUS_BADGE_CLASS[status]}>
                       {STATUS_LABELS[status]}
                     </span>
+                    {publishedAt ? (
+                      <span
+                        className="text-muted"
+                        style={{ fontSize: 13, fontWeight: 400, marginLeft: 10 }}
+                      >
+                        Last published{" "}
+                        {new Date(publishedAt).toLocaleString("en-NG", {
+                          timeZone: "Africa/Lagos",
+                        })}
+                      </span>
+                    ) : null}
                   </h3>
-                  {publishedAt ? (
-                    <p className="mb-0">
-                      Last published {new Date(publishedAt).toLocaleString()}
-                    </p>
-                  ) : null}
+                  <div style={{ fontSize: 14 }}>
+                    {goLiveLoading ? (
+                      <span className="text-muted">
+                        Checking Go Live status…
+                      </span>
+                    ) : goLiveRequest === null ? (
+                      <span className="text-muted">Not live yet.</span>
+                    ) : goLiveRequest.status === "activated" ? (
+                      <span className="badge badge-success">Live</span>
+                    ) : goLiveRequest.shouldEscalate ? (
+                      <span className="text-muted">
+                        Still waiting? Contact us directly at{" "}
+                        <a href="mailto:contact@cyfamod.com">
+                          contact@cyfamod.com
+                        </a>
+                        .
+                      </span>
+                    ) : (
+                      <span className="text-muted">
+                        Go Live request pending review.
+                      </span>
+                    )}
+                    {goLiveError ? (
+                      <span className="d-block" style={{ color: "#dc2626" }}>
+                        {goLiveError}
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
                 <div className="d-flex align-items-center" style={{ gap: 8 }}>
                   <button
                     type="button"
-                    className="btn-fill-lg btn-gradient-yellow btn-hover-bluedark"
+                    className="btn-fill-md btn-gradient-yellow btn-hover-bluedark"
                     onClick={handleOpenPreview}
                     disabled={previewLoading || status === "unconfigured"}
                     title={
@@ -743,20 +782,43 @@ export default function WebsiteManagementPage() {
                   >
                     {previewLoading ? "Loading Preview…" : "Preview"}
                   </button>
-                  {publicUrl ? (
+                  {goLiveRequest?.status === "activated" && publicUrl ? (
                     <a
                       href={publicUrl}
                       target="_blank"
                       rel="noreferrer"
-                      className="btn-fill-lg bg-blue-dark btn-hover-yellow"
+                      className="btn-fill-md bg-blue-dark btn-hover-yellow"
                     >
                       View Public Website
                     </a>
-                  ) : (
-                    <p className="mb-0 text-muted">
-                      Public website link unavailable (school has no slug yet).
-                    </p>
-                  )}
+                  ) : null}
+                  {!goLiveLoading && goLiveRequest?.status !== "activated" ? (
+                    goLiveRequest === null ? (
+                      <button
+                        type="button"
+                        className="btn-fill-md bg-blue-dark btn-hover-yellow"
+                        onClick={handleGoLiveClick}
+                        disabled={goLiveActionLoading}
+                      >
+                        {goLiveActionLoading ? "Submitting…" : "Go Live"}
+                      </button>
+                    ) : !goLiveRequest.shouldEscalate ? (
+                      goLiveRequest.canResend ? (
+                        <button
+                          type="button"
+                          className="btn-fill-md btn-gradient-yellow btn-hover-bluedark"
+                          onClick={handleResendGoLive}
+                          disabled={goLiveActionLoading}
+                        >
+                          {goLiveActionLoading ? "Resending…" : "Resend"}
+                        </button>
+                      ) : (
+                        <span className="text-muted" style={{ fontSize: 13 }}>
+                          Resend available in 48 hours.
+                        </span>
+                      )
+                    ) : null
+                  ) : null}
                 </div>
               </div>
 
@@ -765,80 +827,6 @@ export default function WebsiteManagementPage() {
                   {previewError}
                 </div>
               ) : null}
-
-              <div
-                className="d-flex flex-wrap align-items-center justify-content-between mt-3 pt-3"
-                style={{ borderTop: "1px solid #e2e8f0", gap: 12 }}
-              >
-                <div>
-                  <h4 className="mb-1" style={{ fontSize: "18px" }}>
-                    Go Live
-                  </h4>
-                  {goLiveLoading ? (
-                    <p className="mb-0 text-muted">Checking status…</p>
-                  ) : goLiveRequest === null ? (
-                    <p className="mb-0 text-muted">
-                      Ready for the world to see your school online? Go Live
-                      makes it happen.
-                    </p>
-                  ) : goLiveRequest.status === "activated" ? (
-                    <p className="mb-0">
-                      <span className="badge badge-success">Live</span>{" "}
-                      Your website is live.
-                    </p>
-                  ) : goLiveRequest.shouldEscalate ? (
-                    <p className="mb-0">
-                      Still waiting? Reach out to us directly at{" "}
-                      <a href="mailto:contact@cyfamod.com">
-                        contact@cyfamod.com
-                      </a>{" "}
-                      and we&apos;ll help you get live.
-                    </p>
-                  ) : (
-                    <p className="mb-0 text-muted">
-                      Your Go Live request is pending review. We&apos;ll
-                      notify you once your website is live.
-                    </p>
-                  )}
-                  {goLiveError ? (
-                    <p className="mb-0 mt-1" style={{ color: "#dc2626" }}>
-                      {goLiveError}
-                    </p>
-                  ) : null}
-                </div>
-                {!goLiveLoading && goLiveRequest?.status !== "activated" ? (
-                  <div>
-                    {goLiveRequest === null ? (
-                      <button
-                        type="button"
-                        className="btn-fill-lg bg-blue-dark btn-hover-yellow"
-                        onClick={handleGoLiveClick}
-                        disabled={goLiveActionLoading}
-                      >
-                        {goLiveActionLoading ? "Submitting…" : "Go Live"}
-                      </button>
-                    ) : !goLiveRequest.shouldEscalate ? (
-                      <button
-                        type="button"
-                        className="btn-fill-lg btn-gradient-yellow btn-hover-bluedark"
-                        onClick={handleResendGoLive}
-                        disabled={
-                          goLiveActionLoading || !goLiveRequest.canResend
-                        }
-                        title={
-                          goLiveRequest.canResend
-                            ? undefined
-                            : "You'll be able to resend 48 hours after your last request."
-                        }
-                      >
-                        {goLiveActionLoading
-                          ? "Resending…"
-                          : "Resend notification"}
-                      </button>
-                    ) : null}
-                  </div>
-                ) : null}
-              </div>
 
               <form
                 id="website-management-form"
@@ -1861,8 +1849,16 @@ export default function WebsiteManagementPage() {
                     <button
                       type="button"
                       className="btn-fill-lg bg-blue-dark btn-hover-yellow"
-                      disabled={submittingStatus !== null}
+                      disabled={
+                        submittingStatus !== null ||
+                        goLiveRequest?.status !== "activated"
+                      }
                       onClick={handlePublishClick}
+                      title={
+                        goLiveRequest?.status !== "activated"
+                          ? "Go Live first -- publishing has no visible effect until your website is live."
+                          : undefined
+                      }
                     >
                       {submittingStatus === "published"
                         ? "Publishing…"
@@ -1872,8 +1868,16 @@ export default function WebsiteManagementPage() {
                       <button
                         type="button"
                         className="btn-fill-lg bg-dark-pastel-green btn-hover-yellow"
-                        disabled={submittingStatus !== null}
+                        disabled={
+                          submittingStatus !== null ||
+                          goLiveRequest?.status !== "activated"
+                        }
                         onClick={() => handleSave("unpublished")}
+                        title={
+                          goLiveRequest?.status !== "activated"
+                            ? "Go Live first -- publishing has no visible effect until your website is live."
+                            : undefined
+                        }
                       >
                         {submittingStatus === "unpublished"
                           ? "Unpublishing…"
@@ -1987,9 +1991,9 @@ export default function WebsiteManagementPage() {
           >
             <h5 className="mb-3">Go Live?</h5>
             <p className="mb-4">
-              This lets your school&apos;s website become publicly reachable
-              online. We&apos;ll review your request and notify you as soon
-              as it&apos;s live.
+              This makes your school&apos;s website publicly reachable
+              online. We will review your request and notify you as soon as
+              it is live.
             </p>
             <div className="d-flex justify-content-end" style={{ gap: 8 }}>
               <button

--- a/app/(app)/v28/website-management/page.tsx
+++ b/app/(app)/v28/website-management/page.tsx
@@ -8,10 +8,15 @@ import { publicWebsitePreviewUrl, publicWebsiteUrl } from "@/lib/config";
 import { userHasRole } from "@/lib/roleChecks";
 import {
   createDefaultSchoolWebsite,
+  getGoLiveStatus,
   getPreviewLink,
   getSchoolWebsite,
+  GoLiveCooldownError,
+  GoLiveDomainNotReadyError,
+  requestGoLive,
   saveSchoolWebsite,
   THEME_OPTIONS,
+  type GoLiveRequest,
   type SchoolWebsite,
   type SchoolWebsitePayload,
   type SchoolWebsiteStatus,
@@ -82,6 +87,43 @@ export default function WebsiteManagementPage() {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+
+  const [goLiveRequest, setGoLiveRequest] = useState<GoLiveRequest | null>(
+    null,
+  );
+  const [goLiveLoading, setGoLiveLoading] = useState(true);
+  const [goLiveActionLoading, setGoLiveActionLoading] = useState(false);
+  const [goLiveError, setGoLiveError] = useState<string | null>(null);
+  const [showGoLiveConfirm, setShowGoLiveConfirm] = useState(false);
+
+  useEffect(() => {
+    if (!school) {
+      return;
+    }
+
+    let cancelled = false;
+
+    getGoLiveStatus()
+      .then((request) => {
+        if (!cancelled) {
+          setGoLiveRequest(request);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error("Failed to load Go Live status", error);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setGoLiveLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [school]);
 
   useEffect(() => {
     if (!school) {
@@ -578,6 +620,57 @@ export default function WebsiteManagementPage() {
     }
   };
 
+  const handleGoLiveClick = () => {
+    setGoLiveError(null);
+    setShowGoLiveConfirm(true);
+  };
+
+  const submitGoLiveRequest = async () => {
+    setGoLiveActionLoading(true);
+    setGoLiveError(null);
+    try {
+      const request = await requestGoLive();
+      setGoLiveRequest(request);
+      showToast(
+        goLiveRequest
+          ? "Resent -- we've notified our team again."
+          : "Go Live request sent -- we'll notify you once your website is live.",
+      );
+    } catch (error) {
+      console.error("Failed to request Go Live", error);
+      if (error instanceof GoLiveDomainNotReadyError) {
+        setGoLiveError(error.message);
+      } else if (error instanceof GoLiveCooldownError) {
+        setGoLiveError(
+          "You'll be able to resend 48 hours after your last request.",
+        );
+      } else if (error instanceof ApiError && error.status === 409) {
+        // Already activated server-side (e.g. approved moments ago) --
+        // refresh instead of showing a stale action failure.
+        getGoLiveStatus()
+          .then(setGoLiveRequest)
+          .catch(() => undefined);
+      } else {
+        setGoLiveError(
+          error instanceof Error
+            ? error.message
+            : "Unable to submit your Go Live request. Please try again.",
+        );
+      }
+    } finally {
+      setGoLiveActionLoading(false);
+    }
+  };
+
+  const handleConfirmGoLive = () => {
+    setShowGoLiveConfirm(false);
+    submitGoLiveRequest();
+  };
+
+  const handleResendGoLive = () => {
+    submitGoLiveRequest();
+  };
+
   // Publish always saves the current form state and goes live immediately,
   // so every click gets a confirmation -- not just when there are unsaved
   // changes -- to guard against accidental publishes in general.
@@ -672,6 +765,80 @@ export default function WebsiteManagementPage() {
                   {previewError}
                 </div>
               ) : null}
+
+              <div
+                className="d-flex flex-wrap align-items-center justify-content-between mt-3 pt-3"
+                style={{ borderTop: "1px solid #e2e8f0", gap: 12 }}
+              >
+                <div>
+                  <h4 className="mb-1" style={{ fontSize: "18px" }}>
+                    Go Live
+                  </h4>
+                  {goLiveLoading ? (
+                    <p className="mb-0 text-muted">Checking status…</p>
+                  ) : goLiveRequest === null ? (
+                    <p className="mb-0 text-muted">
+                      Ready for the world to see your school online? Go Live
+                      makes it happen.
+                    </p>
+                  ) : goLiveRequest.status === "activated" ? (
+                    <p className="mb-0">
+                      <span className="badge badge-success">Live</span>{" "}
+                      Your website is live.
+                    </p>
+                  ) : goLiveRequest.shouldEscalate ? (
+                    <p className="mb-0">
+                      Still waiting? Reach out to us directly at{" "}
+                      <a href="mailto:contact@cyfamod.com">
+                        contact@cyfamod.com
+                      </a>{" "}
+                      and we&apos;ll help you get live.
+                    </p>
+                  ) : (
+                    <p className="mb-0 text-muted">
+                      Your Go Live request is pending review. We&apos;ll
+                      notify you once your website is live.
+                    </p>
+                  )}
+                  {goLiveError ? (
+                    <p className="mb-0 mt-1" style={{ color: "#dc2626" }}>
+                      {goLiveError}
+                    </p>
+                  ) : null}
+                </div>
+                {!goLiveLoading && goLiveRequest?.status !== "activated" ? (
+                  <div>
+                    {goLiveRequest === null ? (
+                      <button
+                        type="button"
+                        className="btn-fill-lg bg-blue-dark btn-hover-yellow"
+                        onClick={handleGoLiveClick}
+                        disabled={goLiveActionLoading}
+                      >
+                        {goLiveActionLoading ? "Submitting…" : "Go Live"}
+                      </button>
+                    ) : !goLiveRequest.shouldEscalate ? (
+                      <button
+                        type="button"
+                        className="btn-fill-lg btn-gradient-yellow btn-hover-bluedark"
+                        onClick={handleResendGoLive}
+                        disabled={
+                          goLiveActionLoading || !goLiveRequest.canResend
+                        }
+                        title={
+                          goLiveRequest.canResend
+                            ? undefined
+                            : "You'll be able to resend 48 hours after your last request."
+                        }
+                      >
+                        {goLiveActionLoading
+                          ? "Resending…"
+                          : "Resend notification"}
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
 
               <form
                 id="website-management-form"
@@ -1785,6 +1952,65 @@ export default function WebsiteManagementPage() {
                 disabled={submittingStatus !== null}
               >
                 {submittingStatus === "published" ? "Publishing…" : "Yes, publish"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {showGoLiveConfirm ? (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Confirm Go Live"
+          style={{
+            position: "fixed",
+            inset: 0,
+            zIndex: 1060,
+            background: "rgba(15, 23, 42, 0.6)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            padding: "2rem",
+          }}
+          onClick={() => setShowGoLiveConfirm(false)}
+        >
+          <div
+            style={{
+              background: "#fff",
+              borderRadius: 12,
+              width: "100%",
+              maxWidth: 480,
+              padding: "1.5rem",
+            }}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <h5 className="mb-3">Go Live?</h5>
+            <p className="mb-4">
+              This lets your school&apos;s website become publicly reachable
+              online. We&apos;ll review your request and notify you as soon
+              as it&apos;s live.
+            </p>
+            <div className="d-flex justify-content-end" style={{ gap: 8 }}>
+              <button
+                type="button"
+                className="btn-fill-lg"
+                style={{
+                  color: "#172033",
+                  background: "#f1f5f9",
+                }}
+                onClick={() => setShowGoLiveConfirm(false)}
+                disabled={goLiveActionLoading}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn-fill-lg bg-blue-dark btn-hover-yellow"
+                onClick={handleConfirmGoLive}
+                disabled={goLiveActionLoading}
+              >
+                {goLiveActionLoading ? "Submitting…" : "Yes, go live"}
               </button>
             </div>
           </div>

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -17,16 +17,22 @@ export class ApiError extends Error {
   readonly status: number;
   /** Laravel's per-field validation errors on a 422 response, if present. */
   readonly errors?: Record<string, string[]>;
+  /** The full parsed JSON body, for endpoints that return extra fields
+   * beyond `message`/`errors` on a non-2xx response (e.g. a 429's
+   * `hours_until_resend_available`). */
+  readonly body?: unknown;
 
   constructor(
     message: string,
     status: number,
     errors?: Record<string, string[]>,
+    body?: unknown,
   ) {
     super(message);
     this.name = "ApiError";
     this.status = status;
     this.errors = errors;
+    this.body = body;
   }
 }
 
@@ -95,8 +101,10 @@ export async function apiFetch<T = unknown>(
 
     let message = response.statusText;
     let validationErrors: Record<string, string[]> | undefined;
+    let body: unknown;
     try {
       const data = await response.json();
+      body = data;
       message = data.message ?? JSON.stringify(data);
       if (data.errors && typeof data.errors === "object") {
         validationErrors = data.errors;
@@ -108,6 +116,7 @@ export async function apiFetch<T = unknown>(
       message || `Request failed (${response.status})`,
       response.status,
       validationErrors,
+      body,
     );
   }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -143,6 +143,7 @@ export const API_ROUTES = {
   schoolContext: "/api/v1/school",
   schoolWebsite: "/api/v1/school/website",
   schoolWebsitePreviewLink: "/api/v1/school/website/preview-link",
+  schoolWebsiteGoLive: "/api/v1/school/website/go-live",
   classes: "/api/v1/classes",
   parents: "/api/v1/parents",
   parentsSearch: "/api/v1/parents",

--- a/lib/schoolWebsite.ts
+++ b/lib/schoolWebsite.ts
@@ -230,6 +230,95 @@ export async function getPreviewLink(): Promise<SchoolWebsitePreviewLink> {
   );
 }
 
+export type GoLiveRequestStatus = "pending" | "activated";
+
+export interface GoLiveRequest {
+  status: GoLiveRequestStatus;
+  requestedAt: string;
+  resendCount: number;
+  canResend: boolean;
+  shouldEscalate: boolean;
+}
+
+/** Raw shape returned by sms-enterprise-edition, forwarded as-is by school-be-laravel. */
+interface GoLiveRequestRaw {
+  status: GoLiveRequestStatus;
+  requested_at: string;
+  resend_count: number;
+  can_resend: boolean;
+  should_escalate: boolean;
+}
+
+function toGoLiveRequest(raw: GoLiveRequestRaw): GoLiveRequest {
+  return {
+    status: raw.status,
+    requestedAt: raw.requested_at,
+    resendCount: raw.resend_count,
+    canResend: raw.can_resend,
+    shouldEscalate: raw.should_escalate,
+  };
+}
+
+/**
+ * Current Go Live status for the authenticated school -- `null` means Go
+ * Live has never been requested. Distinct from website `status`
+ * (draft/published/unpublished): this is about the custom domain being
+ * reachable, not the content itself -- see the Go Live section of the
+ * roadmap for why the two are never conflated in this UI.
+ */
+export async function getGoLiveStatus(): Promise<GoLiveRequest | null> {
+  const payload = await apiFetch<{ request: GoLiveRequestRaw | null }>(
+    API_ROUTES.schoolWebsiteGoLive,
+  );
+  return payload.request ? toGoLiveRequest(payload.request) : null;
+}
+
+/** Thrown when the school has no `custom_domain` on file yet -- Cyfamod
+ * hasn't finished setting up their site (see `schools:set-domain` in
+ * school-be-laravel). The caller should show a friendly "still being set
+ * up" message, never the raw backend text. */
+export class GoLiveDomainNotReadyError extends Error {}
+
+/** Thrown when a resend is attempted before the cooldown has passed. */
+export class GoLiveCooldownError extends Error {
+  constructor(
+    message: string,
+    readonly hoursUntilResendAvailable: number,
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Requests Go Live (first time) or resends the notification for an
+ * existing pending request. Never called again once `activated`.
+ */
+export async function requestGoLive(): Promise<GoLiveRequest> {
+  try {
+    const payload = await apiFetch<{ request: GoLiveRequestRaw }>(
+      API_ROUTES.schoolWebsiteGoLive,
+      { method: "POST" },
+    );
+    return toGoLiveRequest(payload.request);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 422) {
+      throw new GoLiveDomainNotReadyError(
+        "Your website is still being set up -- we'll notify you when it's ready to go live.",
+      );
+    }
+    if (error instanceof ApiError && error.status === 429) {
+      const body = error.body as
+        | { hours_until_resend_available?: number }
+        | undefined;
+      throw new GoLiveCooldownError(
+        error.message,
+        Number(body?.hours_until_resend_available ?? 0),
+      );
+    }
+    throw error;
+  }
+}
+
 const THEME_KEY = "kidza-home-2";
 
 /**

--- a/lib/schoolWebsite.ts
+++ b/lib/schoolWebsite.ts
@@ -303,7 +303,7 @@ export async function requestGoLive(): Promise<GoLiveRequest> {
   } catch (error) {
     if (error instanceof ApiError && error.status === 422) {
       throw new GoLiveDomainNotReadyError(
-        "Your website is still being set up -- we'll notify you when it's ready to go live.",
+        "Your website is still being set up -- we will notify you when it is ready to go live.",
       );
     }
     if (error instanceof ApiError && error.status === 429) {


### PR DESCRIPTION
## Description

Adds the missing frontend piece for the Go Live feature -- wires up the already-built backend (`goLive`/`goLiveStatus` endpoints in `school-be-laravel`, backed by `sms-enterprise-edition`'s request/notification/approval workflow).

Labeled "Go Live" everywhere, deliberately never "Publish" -- those are two distinct concepts in this UI: Publish is the website *content* status, Go Live is *custom-domain activation*.

No domain language is exposed to the school. Cyfamod sets up `custom_domain` during onboarding (same as the SMS portal domain -- schools don't pick their own domain, per product decision), so a school only ever sees "Go Live" / "pending" / "Live", never a raw domain-not-set error.

States handled:
- Never requested -- "Go Live" button + confirm dialog.
- Pending -- status banner + a gated "Resend notification" button (disabled during the 48hr cooldown).
- Pending past the escalation threshold -- a "contact us directly" message instead of Resend.
- Activated -- a "Live" badge.

`ApiError` (in `lib/apiClient.ts`) gained an optional `body` field carrying the full response JSON -- needed to read the 429 resend-cooldown response's `hours_until_resend_available`, which the previous `message`/`errors`-only shape couldn't carry.

## How Has This Been Tested?

Ran the entire flow through the real API (not mocked) against a local `school-be-laravel` + `sms-enterprise-edition`, using a domain set via the new `schools:set-domain` command (`school-be-laravel` PR #104):

- Go Live request -> `pending` (real email logged, Discord gracefully skipped with no webhook configured).
- Resend before cooldown -> blocked with `hours_until_resend_available` returned.
- Resend after backdating past cooldown -> succeeds, `resend_count` increments.
- Second resend -> `should_escalate` flips to `true` at the threshold.
- `php artisan activation:approve` -> calls back into `school-be-laravel`, flips `activated`, `goLiveStatus` reflects `activated` immediately.
- Confirmed the public-site gate itself: `published && !activated` -> 404, `published && activated` -> 200.

Every state above was verified to match exactly what this PR's frontend code parses. `tsc --noEmit` and `eslint` both clean (one pre-existing, unrelated lint warning on `dev` untouched).


## Screenshots
<img width="869" height="264" alt="image" src="https://github.com/user-attachments/assets/14ed5a59-c6c0-4190-8ec4-6d66e29a532a" />


## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.