### PR TITLE
ci: add real lint+build pipeline, fix the one blocking lint error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Prepare environment
+        run: cp .env.example .env
+
       - name: Lint
         run: npm run lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - staging
+  pull_request:
+    branches:
+      - dev
+      - staging
+
+jobs:
+  ci:
+    name: Lint and Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/app/(app)/v17/assign-teachers/page.tsx
+++ b/app/(app)/v17/assign-teachers/page.tsx
@@ -1130,7 +1130,7 @@ export default function AssignTeachersPage() {
               </div>
               {groupEditor.existing ? (
                 <small className="text-muted d-block mt-2">
-                  Existing rows are never removed by bulk save. Use the row's Delete button in the list when removal is intended.
+                  Existing rows are never removed by bulk save. Use the row&apos;s Delete button in the list when removal is intended.
                 </small>
               ) : null}
             </form>


### PR DESCRIPTION
## Description

This repo had no CI at all — no `.github/workflows/` directory, and no test suite exists to gate on (no `test` script, no test files anywhere). This adds what can actually be verified today: a reproducible install, lint, and a real production build check.

## What this adds

- `.github/workflows/ci.yml` — installs with `npm ci` against the real, tracked `package-lock.json` (an untracked `pnpm-lock.yaml` some local installs generated was never the actual committed lockfile), runs `npm run lint`, runs `npm run build`.
- Fixes the one real lint error blocking a clean run: an unescaped apostrophe in JSX text (`react/no-unescaped-entities`) in `v17/assign-teachers/page.tsx`.

## What this deliberately leaves alone

- The 42 pre-existing lint **warnings** (unused vars, missing hook deps, `<img>` vs `next/image` suggestions) — real cleanup, but not something to silently fold into a CI-setup PR.
- No deploy/CD step — this repo has no existing deploy pipeline to hook into; scope here is verification only.

## Related Issue

N/A — found while investigating this repo's CI/test coverage alongside the same work already done on the backend repo (`school-be-laravel` #109–#112).

## How Has This Been Tested?

Confirmed locally before writing the workflow: `npm run build` already passes clean on `dev` (exit 0) — this is process debt, not broken code. `npm run lint` now returns 0 errors (42 warnings, unchanged from before).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes (no test infrastructure exists in this repo yet — separate, larger effort).
- [x] All new and existing tests passed (lint + build, the only checks that currently exist).
