### PR TITLE
chore: fix all lint warnings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@
 NEXT_PUBLIC_BACKEND_URL=http://localhost:8000
 
 # Server-only secret (do NOT prefix with NEXT_PUBLIC_)
-COOKIE_SECRET=1ncreaswiblyS3cur3S3cretKey!
-NEXT_PUBLIC_COOKIE_SECRET=1ncreaswiblyS3cur3S3cretKey!
+COOKIE_SECRET=1ncredib1yS3cur3S3cretKey!
+NEXT_PUBLIC_COOKIE_SECRET=1ncredib1yS3cur3S3cretKey!
 
 # Onboarding videos (use embed URLs so iframe query params work reliably)
 NEXT_PUBLIC_ONBOARDING_VIDEO_ADMIN=https://www.youtube.com/embed/l_IY77edZv8

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -54,7 +54,7 @@ export default function AppLayout({
       preloader.remove();
     }, 300);
     return () => window.clearTimeout(timer);
-  }, [loading, user]);
+  }, [loading, user, isCbtStudentRoute]);
 
   if (!user && !isCbtStudentRoute) {
     return loading ? (

--- a/app/(app)/v11/all-sessions/page.tsx
+++ b/app/(app)/v11/all-sessions/page.tsx
@@ -8,7 +8,6 @@ import {
   type Session,
 } from "@/lib/sessions";
 import { useAuth } from "@/contexts/AuthContext";
-import { PermissionGate } from "@/components/PermissionGate";
 import { PERMISSIONS } from "@/lib/permissionKeys";
 
 function formatDate(value?: string | null) {

--- a/app/(app)/v14/bulk-results/page.tsx
+++ b/app/(app)/v14/bulk-results/page.tsx
@@ -6,10 +6,6 @@ import { listSessions, type Session } from "@/lib/sessions";
 import { listTermsBySession, type Term } from "@/lib/terms";
 import { listClasses, type SchoolClass } from "@/lib/classes";
 import { listClassArms, type ClassArm } from "@/lib/classArms";
-import {
-  listClassArmSections,
-  type ClassArmSection,
-} from "@/lib/classArmSections";
 import { resolveBackendUrl } from "@/lib/config";
 import { getCookie } from "@/lib/cookies";
 
@@ -50,7 +46,6 @@ export default function BulkResultsPage() {
   const [termsCache, setTermsCache] = useState<Record<string, Term[]>>({});
   const [classes, setClasses] = useState<SchoolClass[]>([]);
   const [classArms, setClassArms] = useState<ClassArm[]>([]);
-  const [classSections, setClassSections] = useState<ClassArmSection[]>([]);
   const [status, setStatus] = useState<string>("");
   const [processing, setProcessing] = useState(false);
 
@@ -93,7 +88,6 @@ export default function BulkResultsPage() {
         setClassArms(arms);
         if (!arms.find((arm) => `${arm.id}` === filters.classArmId)) {
           setFilters((prev) => ({ ...prev, classArmId: "", classSectionId: "" }));
-          setClassSections([]);
         }
       })
       .catch((error) => {
@@ -291,7 +285,6 @@ export default function BulkResultsPage() {
                     classSectionId: "",
                   }));
                   setClassArms([]);
-                  setClassSections([]);
                 }}
               >
                 <option value="">Select class</option>
@@ -315,9 +308,6 @@ export default function BulkResultsPage() {
                     classArmId: nextArmId,
                     classSectionId: "",
                   }));
-                  if (!nextArmId) {
-                    setClassSections([]);
-                  }
                 }}
                 disabled={!filters.classId || classArms.length === 0}
               >

--- a/app/(app)/v14/class-skill-ratings/page.tsx
+++ b/app/(app)/v14/class-skill-ratings/page.tsx
@@ -102,7 +102,6 @@ export default function ClassSkillRatingsPage() {
 
   const [loadingFilters, setLoadingFilters] = useState(false);
   const [loadingGrid, setLoadingGrid] = useState(false);
-  const [saving, setSaving] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
   const [feedbackKind, setFeedbackKind] = useState<"success" | "info" | "warning" | "danger">("info");
   const [error, setError] = useState<string | null>(null);
@@ -180,14 +179,6 @@ export default function ClassSkillRatingsPage() {
       allowedIds.has(String(schoolClass.id)),
     );
   }, [classes, isTeacher, teacherDashboard]);
-
-  const sections = useMemo(() => {
-    if (!selectedClass || !selectedArm) {
-      return [];
-    }
-    const key = `${selectedClass}:${selectedArm}`;
-    return sectionsCache[key] ?? [];
-  }, [selectedClass, selectedArm, sectionsCache]);
 
   const skillTypeOptions = useMemo(() => {
     return skillTypes
@@ -702,91 +693,6 @@ export default function ClassSkillRatingsPage() {
       },
     [scheduleAutoSave],
   );
-
-  const handleSaveAll = useCallback(async () => {
-    setFeedback(null);
-    setError(null);
-
-    if (!selectedSession || !selectedTerm) {
-      setFeedbackKind("warning");
-      setFeedback("Select session and term before saving ratings.");
-      return;
-    }
-
-    if (!students.length || !visibleSkillTypes.length) {
-      setFeedbackKind("info");
-      setFeedback("Load students and select a skill before saving.");
-      return;
-    }
-
-    const tasks: Array<Promise<unknown>> = [];
-
-    students.forEach((student) => {
-      const studentRow = ratingsGrid[String(student.id)] ?? {};
-      visibleSkillTypes.forEach((type) => {
-        const cell = studentRow[String(type.id)];
-        const value = cell?.value?.trim() ?? "";
-        if (!value) {
-          return;
-        }
-        const ratingValue = Number(value);
-        if (!Number.isFinite(ratingValue) || ratingValue < 0 || ratingValue > 5) {
-          return;
-        }
-
-        if (cell.ratingId) {
-          tasks.push(
-            updateStudentSkillRating(student.id, cell.ratingId, {
-              session_id: selectedSession,
-              term_id: selectedTerm,
-              skill_type_id: String(type.id),
-              rating_value: ratingValue,
-            }),
-          );
-        } else {
-          tasks.push(
-            createStudentSkillRating(student.id, {
-              session_id: selectedSession,
-              term_id: selectedTerm,
-              skill_type_id: String(type.id),
-              rating_value: ratingValue,
-            }),
-          );
-        }
-      });
-    });
-
-    if (!tasks.length) {
-      setFeedbackKind("info");
-      setFeedback("No ratings to save for the selected skill.");
-      return;
-    }
-
-    setSaving(true);
-    try {
-      await Promise.all(tasks);
-      await handleLoadGrid();
-      setFeedbackKind("success");
-      setFeedback("Skill ratings saved successfully for the class.");
-    } catch (err) {
-      console.error("Unable to save class skill ratings", err);
-      setFeedbackKind("danger");
-      setFeedback(
-        err instanceof Error
-          ? err.message
-          : "Unable to save skill ratings at this time.",
-      );
-    } finally {
-      setSaving(false);
-    }
-  }, [
-    handleLoadGrid,
-    ratingsGrid,
-    selectedSession,
-    selectedTerm,
-    skillTypes,
-    students,
-  ]);
 
   return (
     <>

--- a/app/(app)/v14/student-details/page.tsx
+++ b/app/(app)/v14/student-details/page.tsx
@@ -193,7 +193,6 @@ export default function StudentDetailsPage() {
   const [removing, setRemoving] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [deletionDependencies, setDeletionDependencies] = useState<string[]>([]);
-  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [resettingStudentPassword, setResettingStudentPassword] = useState(false);
   const [passwordResetFeedback, setPasswordResetFeedback] = useState<string | null>(null);
   const [passwordResetError, setPasswordResetError] = useState<string | null>(null);
@@ -1714,7 +1713,6 @@ export default function StudentDetailsPage() {
       return;
     }
     setRemoving(true);
-    setDeleteError(null);
     setDeletionDependencies([]);
 
     try {
@@ -1740,13 +1738,11 @@ export default function StudentDetailsPage() {
 
       const errorMessage =
         err instanceof Error ? err.message : "Unable to delete student.";
-      setDeleteError(errorMessage);
       alert(errorMessage);
     }
   };
 
   const handleDeleteClick = () => {
-    setDeleteError(null);
     setDeletionDependencies([]);
     if (
       window.confirm(
@@ -2888,7 +2884,6 @@ export default function StudentDetailsPage() {
           router.push(allStudentsHref);
         }}
         onDeleteError={(errorMsg) => {
-          setDeleteError(errorMsg);
           alert(errorMsg);
         }}
       />

--- a/app/(app)/v15/all-staff/page.tsx
+++ b/app/(app)/v15/all-staff/page.tsx
@@ -9,7 +9,6 @@ import {
   type StaffListResponse,
 } from "@/lib/staff";
 import { useAuth } from "@/contexts/AuthContext";
-import { PermissionGate } from "@/components/PermissionGate";
 import { PERMISSIONS } from "@/lib/permissionKeys";
 
 interface FilterState {

--- a/app/(app)/v17/assign-subjects/page.tsx
+++ b/app/(app)/v17/assign-subjects/page.tsx
@@ -190,28 +190,12 @@ export default function AssignSubjectsPage() {
     return armsCache[form.school_class_id] ?? [];
   }, [armsCache, form.school_class_id]);
 
-  const sectionsForSelection = useMemo(() => {
-    if (!form.school_class_id || !form.class_arm_id) {
-      return [];
-    }
-    const key = `${form.school_class_id}:${form.class_arm_id}`;
-    return sectionsCache[key] ?? [];
-  }, [sectionsCache, form.school_class_id, form.class_arm_id]);
-
   const filterArms = useMemo(() => {
     if (!filters.school_class_id) {
       return [];
     }
     return armsCache[filters.school_class_id] ?? [];
   }, [armsCache, filters.school_class_id]);
-
-  const filterSections = useMemo(() => {
-    if (!filters.school_class_id || !filters.class_arm_id) {
-      return [];
-    }
-    const key = `${filters.school_class_id}:${filters.class_arm_id}`;
-    return sectionsCache[key] ?? [];
-  }, [sectionsCache, filters.school_class_id, filters.class_arm_id]);
 
   useEffect(() => {
     listAllSubjects()

--- a/app/(app)/v17/assign-teachers/page.tsx
+++ b/app/(app)/v17/assign-teachers/page.tsx
@@ -265,21 +265,6 @@ export default function AssignTeachersPage() {
     [],
   );
 
-  const classArmsForForm = useMemo(() => {
-    if (!form.school_class_id) {
-      return [];
-    }
-    return classArmsByClass[form.school_class_id] ?? [];
-  }, [classArmsByClass, form.school_class_id]);
-
-  const classSectionsForForm = useMemo(() => {
-    if (!form.school_class_id || !form.class_arm_id) {
-      return [];
-    }
-    const key = `${form.school_class_id}:${form.class_arm_id}`;
-    return classSectionsByKey[key] ?? [];
-  }, [classSectionsByKey, form.school_class_id, form.class_arm_id]);
-
   const selectedContexts = useMemo<SubjectTeacherAssignmentContext[]>(() => {
     if (editingId) {
       if (!form.school_class_id) {
@@ -358,14 +343,6 @@ export default function AssignTeachersPage() {
     }
     return classArmsByClass[filters.school_class_id] ?? [];
   }, [classArmsByClass, filters.school_class_id]);
-
-  const classSectionsForFilter = useMemo(() => {
-    if (!filters.school_class_id || !filters.class_arm_id) {
-      return [];
-    }
-    const key = `${filters.school_class_id}:${filters.class_arm_id}`;
-    return classSectionsByKey[key] ?? [];
-  }, [classSectionsByKey, filters.school_class_id, filters.class_arm_id]);
 
   const selectedStudentCount = useMemo(() => {
     return Object.values(selectedStudentIds).filter(Boolean).length;

--- a/app/(app)/v18/assign-class-teachers/page.tsx
+++ b/app/(app)/v18/assign-class-teachers/page.tsx
@@ -191,14 +191,6 @@ export default function AssignClassTeachersPage() {
     return armsCache[form.school_class_id] ?? [];
   }, [armsCache, form.school_class_id]);
 
-  const sectionsForForm = useMemo(() => {
-    if (!form.school_class_id || !form.class_arm_id) {
-      return [];
-    }
-    const key = `${form.school_class_id}:${form.class_arm_id}`;
-    return sectionsCache[key] ?? [];
-  }, [sectionsCache, form.school_class_id, form.class_arm_id]);
-
   const armsForFilter = useMemo(() => {
     if (!filters.school_class_id) {
       return [];
@@ -206,13 +198,6 @@ export default function AssignClassTeachersPage() {
     return armsCache[filters.school_class_id] ?? [];
   }, [armsCache, filters.school_class_id]);
 
-  const sectionsForFilter = useMemo(() => {
-    if (!filters.school_class_id || !filters.class_arm_id) {
-      return [];
-    }
-    const key = `${filters.school_class_id}:${filters.class_arm_id}`;
-    return sectionsCache[key] ?? [];
-  }, [sectionsCache, filters.school_class_id, filters.class_arm_id]);
 
   const fetchAssignments = useCallback(async () => {
     setLoadingList(true);

--- a/app/(app)/v19/assessment-components/[componentId]/structures/page.tsx
+++ b/app/(app)/v19/assessment-components/[componentId]/structures/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { apiFetch } from '@/lib/apiClient';
 import { getErrorMessage } from "@/lib/errors";
@@ -32,11 +32,6 @@ interface SchoolClass {
   name: string;
 }
 
-interface SessionTerm {
-  id: string;
-  name: string;
-}
-
 const statusBadgeClass = (isActive: boolean): string => {
   return isActive ? 'badge badge-success' : 'badge badge-secondary';
 };
@@ -48,7 +43,6 @@ export default function AssessmentComponentStructures() {
   const [component, setComponent] = useState<AssessmentComponent | null>(null);
   const [structures, setStructures] = useState<Structure[]>([]);
   const [classes, setClasses] = useState<SchoolClass[]>([]);
-  const [terms, setTerms] = useState<SessionTerm[]>([]);
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -80,36 +74,33 @@ export default function AssessmentComponentStructures() {
     is_active: true,
   });
 
-  useEffect(() => {
-    loadData();
-  }, [componentId]);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true);
       setError('');
 
-      const [structuresRes, classesRes, termsRes] = (await Promise.all([
+      const [structuresRes, classesRes] = (await Promise.all([
         apiFetch(`/api/v1/settings/assessment-component-structures/component/${componentId}`),
         apiFetch('/api/v1/classes'),
-        apiFetch('/api/v1/terms'),
       ])) as [
         { component?: AssessmentComponent; structures?: Structure[] },
         SchoolClass[] | { data?: SchoolClass[] },
-        SessionTerm[] | { data?: SessionTerm[] },
       ];
 
       setComponent(structuresRes?.component ?? null);
       setStructures(structuresRes?.structures || []);
       setClasses(Array.isArray(classesRes) ? classesRes : classesRes?.data || []);
-      setTerms(Array.isArray(termsRes) ? termsRes : termsRes?.data || []);
     } catch (err) {
       console.error('Error loading data:', err);
       setError('Failed to load data');
     } finally {
       setLoading(false);
     }
-  };
+  }, [componentId]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/app/(app)/v19/results-entry/page.tsx
+++ b/app/(app)/v19/results-entry/page.tsx
@@ -153,7 +153,6 @@ export default function ResultsEntryPage() {
   const [componentLoading, setComponentLoading] = useState(false);
   const [initializing, setInitializing] = useState(true);
   const [tableLoading, setTableLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
   const autoSaveTimersRef = useRef<Record<string, number>>({});
   const lastAutoSaveKeyRef = useRef<Record<string, string>>({});
 
@@ -311,13 +310,6 @@ export default function ResultsEntryPage() {
     return armsCache[selectedClass] ?? [];
   }, [selectedClass, armsCache]);
 
-  const sections = useMemo(() => {
-    if (!selectedClass || !selectedArm) {
-      return [];
-    }
-    const key = `${selectedClass}:${selectedArm}`;
-    return sectionsCache[key] ?? [];
-  }, [selectedClass, selectedArm, sectionsCache]);
 
   // Filter subjects based on the selected class
   const filteredSubjects = useMemo(() => {
@@ -871,6 +863,10 @@ export default function ResultsEntryPage() {
     }));
   };
 
+  // The section selector below is commented out per request (UI hidden,
+  // logic preserved for future use), so this handler has no live caller
+  // right now -- kept intentionally, not dead code.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleSectionChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const value = event.target.value;
     updateFilters((prev) => ({
@@ -1395,265 +1391,6 @@ export default function ResultsEntryPage() {
     selectedSubject,
   ]);
 
-  const handleSaveResults = useCallback(async () => {
-    resetMessages();
-
-    if (!rows.length) {
-      setFeedback({
-        type: "info",
-        message: "Load students before attempting to save.",
-      });
-      return;
-    }
-
-    if (!selectedSession || !selectedTerm || !selectedSubject) {
-      setFeedback({
-        type: "warning",
-        message: "Select session, term, and subject before saving scores.",
-      });
-      return;
-    }
-
-    if (isTeacher && !canEditSelectedSubject) {
-      setFeedback({
-        type: "warning",
-        message:
-          "You can view this subject because you are a class teacher, but scores can only be entered for subjects assigned to you.",
-      });
-      return;
-    }
-
-    if (!displayComponents.length) {
-      setFeedback({
-        type: "info",
-        message: "No assessment components available to save.",
-      });
-      return;
-    }
-
-    const nextRows = rows.map((row) => ({
-      ...row,
-      cells: { ...row.cells },
-    }));
-    const entriesByComponent: Record<string, Array<{
-      student_id: number | string;
-      subject_id: string;
-      score: number;
-      remarks: string | null;
-    }>> = {};
-    let hasErrors = false;
-
-    nextRows.forEach((row) => {
-      displayComponents.forEach((component) => {
-        const componentId = String(component.id);
-        const cell = row.cells[componentId];
-        if (!cell) {
-          return;
-        }
-        const scoreInput = cell.score.trim();
-        const remarkInput = cell.remark.trim();
-        const originalRemark = cell.originalRemark.trim();
-        const originalScore = cell.originalScore.trim();
-
-        const changed =
-          scoreInput !== originalScore || remarkInput !== originalRemark;
-
-        if (!changed) {
-          row.cells[componentId] = {
-            ...cell,
-            rowError: null,
-            status: cell.hasResult ? "saved" : "none",
-          };
-          return;
-        }
-
-        if (!scoreInput) {
-          row.cells[componentId] = {
-            ...cell,
-            rowError:
-              "Score is required when updating a result or providing a remark.",
-            status: "pending",
-          };
-          hasErrors = true;
-          return;
-        }
-
-        const scoreValue = Number(scoreInput);
-        const maxScore = getComponentMaxScore(componentId);
-        if (
-          Number.isNaN(scoreValue) ||
-          scoreValue < 0 ||
-          scoreValue > maxScore
-        ) {
-          row.cells[componentId] = {
-            ...cell,
-            rowError: `Score must be a number between 0 and ${getComponentMaxScoreLabel(componentId)}.`,
-            status: "pending",
-          };
-          hasErrors = true;
-          return;
-        }
-
-        row.cells[componentId] = {
-          ...cell,
-          rowError: null,
-          status: "pending",
-        };
-
-        if (!entriesByComponent[componentId]) {
-          entriesByComponent[componentId] = [];
-        }
-        entriesByComponent[componentId].push({
-          student_id: row.student.id,
-          subject_id: selectedSubject,
-          score: Number.parseFloat(scoreValue.toFixed(2)),
-          remarks: remarkInput ? remarkInput : null,
-        });
-      });
-    });
-
-    setRows(nextRows);
-
-    if (hasErrors) {
-      setFeedback({
-        type: "danger",
-        message: "Please fix the highlighted rows before saving.",
-      });
-      return;
-    }
-
-    const totalEntries = Object.values(entriesByComponent).reduce(
-      (sum, entries) => sum + entries.length,
-      0,
-    );
-
-    if (!totalEntries) {
-      setFeedback({
-        type: "info",
-        message: "No changes to save.",
-      });
-      return;
-    }
-
-    setSaving(true);
-    setStatusMessage("Saving scores...");
-
-    try {
-      const saveTasks = Object.entries(entriesByComponent).map(
-        ([componentId, entries]) => ({
-          componentId,
-          promise: saveResultsBatch({
-            session_id: selectedSession,
-            term_id: selectedTerm,
-            assessment_component_id: componentId,
-            entries,
-          }),
-        }),
-      );
-
-      const results = await Promise.allSettled(
-        saveTasks.map((task) => task.promise),
-      );
-
-      const updatedMap = new Map<string, ResultRecord>();
-      const failedComponentIds = new Set<string>();
-      let savedCount = 0;
-
-      results.forEach((result, index) => {
-        const componentId = saveTasks[index].componentId;
-        if (result.status === "fulfilled") {
-          result.value.results.forEach((item) => {
-            const key = `${item.student_id}-${String(item.assessment_component_id ?? componentId)}`;
-            updatedMap.set(key, item);
-          });
-          savedCount += result.value.results.length;
-        } else {
-          failedComponentIds.add(componentId);
-        }
-      });
-
-      setRows((prev) =>
-        prev.map((row) => {
-          const nextCells = { ...row.cells };
-          displayComponents.forEach((component) => {
-            const componentId = String(component.id);
-            if (failedComponentIds.has(componentId)) {
-              return;
-            }
-            const saved = updatedMap.get(
-              `${row.student.id}-${componentId}`,
-            );
-            const cell = nextCells[componentId];
-            if (!cell) {
-              return;
-            }
-            if (!saved) {
-              nextCells[componentId] = {
-                ...cell,
-                rowError: null,
-                status: cell.hasResult ? "saved" : "none",
-              };
-              return;
-            }
-            const savedScore = formatScore(saved.total_score);
-            const savedRemark = (saved.remarks ?? "").trim();
-            nextCells[componentId] = {
-              ...cell,
-              score: savedScore,
-              remark: saved.remarks ?? "",
-              originalScore: savedScore,
-              originalRemark: savedRemark,
-              hasResult: true,
-              status: "saved",
-              rowError: null,
-            };
-          });
-          return {
-            ...row,
-            cells: nextCells,
-          };
-        }),
-      );
-
-      if (failedComponentIds.size) {
-        setFeedback({
-          type: "danger",
-          message: `Scores saved for ${savedCount} entries, but ${failedComponentIds.size} component batch${failedComponentIds.size === 1 ? "" : "es"} failed.`,
-        });
-      } else {
-        setFeedback({
-          type: "success",
-          message: "Scores saved successfully.",
-        });
-      }
-
-      setStatusMessage(`Saved ${savedCount} entries.`);
-    } catch (error) {
-      console.error("Unable to save scores", error);
-      setFeedback({
-        type: "danger",
-        message:
-          error instanceof Error
-            ? error.message
-            : "Unable to save scores at this time.",
-      });
-      setStatusMessage("");
-    } finally {
-      setSaving(false);
-    }
-  }, [
-    displayComponents,
-    canEditSelectedSubject,
-    isTeacher,
-    getComponentMaxScore,
-    getComponentMaxScoreLabel,
-    resetMessages,
-    rows,
-    selectedSession,
-    selectedTerm,
-    selectedSubject,
-  ]);
-
   return (
     <>
       <div className="breadcrumbs-area">
@@ -1828,7 +1565,7 @@ export default function ResultsEntryPage() {
                 onClick={() => {
                   void handleLoadStudents();
                 }}
-                disabled={tableLoading || saving || initializing}
+                disabled={tableLoading || initializing}
               >
                 {tableLoading ? "Loading…" : "Load Students"}
               </button>

--- a/app/(app)/v20/student-promotion/page.tsx
+++ b/app/(app)/v20/student-promotion/page.tsx
@@ -186,28 +186,12 @@ export default function StudentPromotionPage() {
     return armsCache[filters.school_class_id] ?? [];
   }, [filters.school_class_id, armsCache]);
 
-  const sectionsForFilter = useMemo(() => {
-    if (!filters.school_class_id || !filters.class_arm_id) {
-      return [];
-    }
-    const key = `${filters.school_class_id}:${filters.class_arm_id}`;
-    return sectionsCache[key] ?? [];
-  }, [filters.school_class_id, filters.class_arm_id, sectionsCache]);
-
   const targetArms = useMemo(() => {
     if (!target.school_class_id) {
       return [];
     }
     return armsCache[target.school_class_id] ?? [];
   }, [target.school_class_id, armsCache]);
-
-  const targetSections = useMemo(() => {
-    if (!target.school_class_id || !target.class_arm_id) {
-      return [];
-    }
-    const key = `${target.school_class_id}:${target.class_arm_id}`;
-    return sectionsCache[key] ?? [];
-  }, [target.school_class_id, target.class_arm_id, sectionsCache]);
 
   const toggleStudentSelection = (studentId: number, checked: boolean) => {
     setSelectedIds((prev) => {

--- a/app/(app)/v21/student-attendance/page.tsx
+++ b/app/(app)/v21/student-attendance/page.tsx
@@ -85,7 +85,7 @@ export default function StudentAttendancePage() {
 
   const lockSessionAndTerm = isTeacher;
 
-  const [date, setDate] = useState<string>(todayIso);
+  const [date] = useState<string>(todayIso);
   const [sessions, setSessions] = useState<Session[]>([]);
   const [termsCache, setTermsCache] = useState<Record<string, Term[]>>({});
   const [classes, setClasses] = useState<SchoolClass[]>([]);

--- a/app/(app)/v24/roles/page.tsx
+++ b/app/(app)/v24/roles/page.tsx
@@ -6,7 +6,6 @@ import {
   useEffect,
   useMemo,
   useState,
-  type ReactNode,
 } from "react";
 import { useAuth } from "@/contexts/AuthContext";
 import { PERMISSION_ACTIONS } from "@/lib/permissionCatalog";
@@ -365,36 +364,6 @@ const collectPermissionGroups = (
   return groups;
 };
 
-const summarizeRolePermissions = (role: Role): ReactNode => {
-  const permissions = Array.isArray(role.permissions)
-    ? role.permissions
-    : [];
-  if (permissions.length === 0) {
-    return <span className="badge badge-secondary">None</span>;
-  }
-
-  const names = permissions
-    .map((permission) =>
-      typeof permission?.name === "string" ? permission.name : "",
-    )
-    .filter((value) => value.trim().length > 0);
-
-  if (!names.length) {
-    return <span className="badge badge-secondary">None</span>;
-  }
-
-  const preview = names.slice(0, 3).join(", ");
-  const remaining = names.length - 3;
-
-  return (
-    <>
-      {preview}
-      {remaining > 0 ? (
-        <span className="text-muted"> (+{remaining} more)</span>
-      ) : null}
-    </>
-  );
-};
 
 const containsManageTerm = (...values: Array<string | null | undefined>): boolean => {
   const text = values

--- a/app/(app)/v27/cbt/[quizId]/take/page.tsx
+++ b/app/(app)/v27/cbt/[quizId]/take/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { StudentAuthProvider, useStudentAuth } from '@/contexts/StudentAuthContext';
 import { apiFetch } from '@/lib/apiClient';
@@ -109,56 +109,7 @@ function TakeQuizPageInner() {
     }
   }, [authLoading, student, quizId, router]);
 
-  // Timer effect
-  useEffect(() => {
-    if (timeRemaining <= 0 || !attemptId) return;
-
-    const timer = setInterval(() => {
-      setTimeRemaining((prev) => {
-        if (prev <= 1) {
-          // Auto-submit quiz when time expires
-          submitQuiz();
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, [timeRemaining, attemptId]);
-
-  const formatTime = (seconds: number): string => {
-    const hours = Math.floor(seconds / 3600);
-    const minutes = Math.floor((seconds % 3600) / 60);
-    const secs = seconds % 60;
-
-    if (hours > 0) {
-      return `${hours}h ${minutes}m ${secs}s`;
-    }
-    return `${minutes}m ${secs}s`;
-  };
-
-  const handleAnswerChange = (answer: QuizAnswer) => {
-    setAnswers(new Map(answers.set(answer.questionId, answer)));
-  };
-
-  const handleNext = () => {
-    if (currentQuestionIndex < questions.length - 1) {
-      setCurrentQuestionIndex(currentQuestionIndex + 1);
-    }
-  };
-
-  const handlePrevious = () => {
-    if (currentQuestionIndex > 0) {
-      setCurrentQuestionIndex(currentQuestionIndex - 1);
-    }
-  };
-
-  const handleGoToQuestion = (index: number) => {
-    setCurrentQuestionIndex(index);
-  };
-
-  const submitQuiz = async () => {
+  const submitQuiz = useCallback(async () => {
     if (!attemptId) return;
 
     try {
@@ -206,7 +157,57 @@ function TakeQuizPageInner() {
       setError(getErrorMessage(err, 'Failed to submit quiz'));
       console.error('Error submitting quiz:', err);
     }
+  }, [attemptId, answers, questions, router]);
+
+  // Timer effect
+  useEffect(() => {
+    if (timeRemaining <= 0 || !attemptId) return;
+
+    const timer = setInterval(() => {
+      setTimeRemaining((prev) => {
+        if (prev <= 1) {
+          // Auto-submit quiz when time expires
+          submitQuiz();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [timeRemaining, attemptId, submitQuiz]);
+
+  const formatTime = (seconds: number): string => {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+
+    if (hours > 0) {
+      return `${hours}h ${minutes}m ${secs}s`;
+    }
+    return `${minutes}m ${secs}s`;
   };
+
+  const handleAnswerChange = (answer: QuizAnswer) => {
+    setAnswers(new Map(answers.set(answer.questionId, answer)));
+  };
+
+  const handleNext = () => {
+    if (currentQuestionIndex < questions.length - 1) {
+      setCurrentQuestionIndex(currentQuestionIndex + 1);
+    }
+  };
+
+  const handlePrevious = () => {
+    if (currentQuestionIndex > 0) {
+      setCurrentQuestionIndex(currentQuestionIndex - 1);
+    }
+  };
+
+  const handleGoToQuestion = (index: number) => {
+    setCurrentQuestionIndex(index);
+  };
+
 
   if (authLoading || loading) {
     return (
@@ -741,6 +742,12 @@ function TakeQuizPageInner() {
             </div>
 
             {currentQuestion.image_url && (
+              // Admin-uploaded question images: unknown intrinsic
+              // dimensions, arbitrary source hosts. next/image needs
+              // real width/height (or `fill` + a sized parent) -- not
+              // safe to guess without visually checking every existing
+              // question image.
+              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={currentQuestion.image_url}
                 alt="Question"

--- a/app/(app)/v27/cbt/admin/cbt-link/page.tsx
+++ b/app/(app)/v27/cbt/admin/cbt-link/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiFetch } from "@/lib/apiClient";

--- a/app/(app)/v27/cbt/history/page.tsx
+++ b/app/(app)/v27/cbt/history/page.tsx
@@ -34,7 +34,7 @@ export default function HistoryPage() {
     }
 
     loadHistory();
-  }, [user]);
+  }, [user, router]);
 
   const loadHistory = async () => {
     try {

--- a/app/(app)/v27/cbt/login/page.tsx
+++ b/app/(app)/v27/cbt/login/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { FormEvent, Suspense, useState } from 'react';
@@ -122,9 +123,11 @@ function CBTStudentLoginPageInner() {
         <div className="login-box">
           <div className="item-logo mb-4">
             <Link href="/" className="d-inline-flex align-items-center">
-              <img
+              <Image
                 src="/assets/img/logo2.png"
                 alt="Quiz Portal Logo"
+                width={210}
+                height={50}
                 style={{ maxWidth: '160px', height: 'auto' }}
               />
             </Link>

--- a/app/(student)/v26/student-dashboard/bio-data/page.tsx
+++ b/app/(student)/v26/student-dashboard/bio-data/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useStudentAuth } from "@/contexts/StudentAuthContext";
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { updateStudentProfile } from "@/lib/studentAuth";
 import { upsertStudentParent } from "@/lib/studentParents";
 import { listCountries, listStates, listLgas, listBloodGroups } from "@/lib/locations";
@@ -873,6 +873,11 @@ export default function StudentBioDataPage() {
                       />
                       {passportPreview && typeof passportPreview === "string" && (passportPreview.startsWith("data:") || passportPreview.startsWith("http://") || passportPreview.startsWith("https://") || passportPreview.startsWith("/")) ? (
                         <>
+                          {/* User-uploaded passport preview: source can be
+                              a data: URI or an arbitrary remote URL with
+                              unknown dimensions -- not safe to guess a
+                              fixed size for next/image without visual QA. */}
+                          {/* eslint-disable-next-line @next/next/no-img-element */}
                           <img
                             src={passportPreview}
                             alt="Passport preview"

--- a/app/(student)/v26/student-dashboard/page.tsx
+++ b/app/(student)/v26/student-dashboard/page.tsx
@@ -578,6 +578,11 @@ export default function StudentDashboardHome() {
                   {/* Profile Avatar */}
                   <div className="profile-avatar-wrapper">
                     {student.photo_url ? (
+                      // Student profile photo: arbitrary source URL,
+                      // unknown dimensions, sized purely by the
+                      // .profile-avatar CSS class -- not safe to guess a
+                      // fixed size for next/image without visual QA.
+                      // eslint-disable-next-line @next/next/no-img-element
                       <img
                         src={student.photo_url}
                         alt={`${student.first_name}'s photo`}

--- a/app/student-login/page.tsx
+++ b/app/student-login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { FormEvent, useState } from "react";
@@ -147,9 +148,11 @@ export default function StudentLoginPage() {
         <div className="login-box">
           <div className="item-logo mb-4">
             <Link href="/" className="d-inline-flex align-items-center">
-              <img
+              <Image
                 src="/assets/img/logo2.png"
                 alt="Result Portal Logo"
+                width={210}
+                height={50}
                 style={{ maxWidth: "160px", height: "auto" }}
               />
             </Link>

--- a/components/DeleteStudentModal.tsx
+++ b/components/DeleteStudentModal.tsx
@@ -1,11 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import {
-  deleteStudent,
-  deleteDependentRecords,
-  StudentDelectionWithDependenciesError,
-} from "@/lib/students";
+import { deleteStudent, deleteDependentRecords } from "@/lib/students";
 
 interface DeleteStudentModalProps {
   isOpen: boolean;
@@ -24,10 +20,16 @@ export default function DeleteStudentModal({
   dependencies = [],
   onClose,
   onDeleteSuccess,
+  // Never actually called below -- this modal shows its own inline error
+  // UI (see the `error` state) instead of delegating to the caller. Kept
+  // in the props contract since callers (e.g. student-details/page.tsx)
+  // already pass a real handler for it; worth deciding deliberately
+  // whether errors should also bubble up through this callback, rather
+  // than silently dropping it here.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onDeleteError,
 }: DeleteStudentModalProps) {
   const [isDeleting, setIsDeleting] = useState(false);
-  const [deleteWithRecords, setDeleteWithRecords] = useState(false);
   const [deletingStatus, setDeletingStatus] = useState<string>("");
   const [error, setError] = useState<string>("");
 
@@ -35,7 +37,6 @@ export default function DeleteStudentModal({
     if (!studentId) return;
 
     setIsDeleting(true);
-    setDeleteWithRecords(true);
     setError("");
     setDeletingStatus("Deleting dependent records...");
 
@@ -64,7 +65,6 @@ export default function DeleteStudentModal({
     if (!studentId) return;
 
     setIsDeleting(true);
-    setDeleteWithRecords(false);
     setError("");
     setDeletingStatus("Deleting student record...");
 


### PR DESCRIPTION
## Description

Went through the 39 lint warnings individually rather than blanket-suppressing. `npm run lint` now returns 0 warnings, 0 errors; `npm run build` passes clean.

## What this fixes

**Genuinely dead code removed** — state/memos set but never actually read anywhere, leftover from features that moved to a different UI pattern (e.g. per-cell autosave replacing a bulk-save button):
- Unused imports/types across ~15 files
- Dead class-section-picker state across 6 pages, never wired to any dropdown
- A **246-line orphaned bulk-save handler** in `results-entry/page.tsx`, fully superseded by an already-wired per-cell autosave elsewhere in the same file (same pattern already found and fixed in `class-skill-ratings/page.tsx`'s `handleSaveAll`)
- The `saving` state it exclusively drove, which was permanently stuck `false` as a result

**One real bug found, deliberately not fixed blind:** `DeleteStudentModal`'s `onDeleteError` prop is never called — the modal shows its own inline error instead. Left in place with a comment flagging it, since the parent already shows an `alert()` on this same callback and wiring it in myself could produce a double popup — a real UX decision, not a safe lint fix.

**React hook dependency warnings**, each checked before fixing:
- Two were safe to add directly (stable values)
- `v27/cbt/[quizId]/take/page.tsx`: `submitQuiz` was declared *after* the effect referencing it — adding it to deps as-is would have been a real `ReferenceError` (confirmed via `next build`, not just eslint). Moved the function above the effect and wrapped it in `useCallback`.

**`<img>` vs `next/image`**, decided per-image:
- 2 static local logo assets (known 210×50 size) converted properly
- 3 dynamic/user-generated images (question images, passport uploads, profile photos — unknown dimensions, arbitrary URLs) left as `<img>` with an explanatory comment — guessing a fixed size risked visibly distorting real content with no way to visually verify.

Also fixes the `.env.example` placeholder secret typo (`1ncreaswiblyS3cur3S3cretKey!` → `1ncredib1yS3cur3S3cretKey!`, an example value, not a real secret).

## Related Issue

N/A — requested lint cleanup, bundled with the `.env.example` typo fix per request.

## How Has This Been Tested?

`npm run lint` (0 warnings) and `npm run build` (passes clean) after every meaningful change, not just once at the end.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] All new and existing tests passed (lint + build, the only checks that exist).
